### PR TITLE
H001075

### DIFF
--- a/members/H001075.yaml
+++ b/members/H001075.yaml
@@ -47,6 +47,8 @@ contact_form:
           selector: textarea#edit-submitted-message-details-message
           value: $MESSAGE
           required: true
+          options:
+            blacklist: "-"
     - select:
         - name: prefix
           selector: select#edit-submitted-constituent-information-prefix


### PR DESCRIPTION
Blacklisting hyphens from Kamala Harris's form because her form is rejecting submissions that have double-hyphen ("--").