### PR TITLE
Update US Sen Yamls with JS Step (VAN-51476)

### DIFF
--- a/members/B000944.yaml
+++ b/members/B000944.yaml
@@ -42,9 +42,11 @@ contact_form:
         selector: "#verify_email"
         value: "$EMAIL"
         required: true
-      - name: comments
-        selector: "#comments"
-        value: "$MESSAGE"
+    - javascript:
+      - name: Message
+        selectors: [ "#comments" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - select:
       - name: salutation

--- a/members/B001135.yaml
+++ b/members/B001135.yaml
@@ -52,9 +52,11 @@ contact_form:
           selector: "#subjecttext"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: salutation

--- a/members/B001230.yaml
+++ b/members/B001230.yaml
@@ -53,9 +53,11 @@ contact_form:
         selector: input#input-561C6766-5056-A066-60C9-A3C3AE42D8BE
         value: $SUBJECT
         required: true
-      - name: message
-        selector: textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2
-        value: $MESSAGE
+    - javascript:
+      - name: Message
+        selectors: [ "textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - select:
       - name: prefix

--- a/members/B001267.yaml
+++ b/members/B001267.yaml
@@ -49,9 +49,11 @@ contact_form:
           selector: "#gen-fieldid-25"
           value: $SUBJECT
           required: true
-        - name: msg
-          selector: "#gen-fieldid-27"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#gen-fieldid-27" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: Prefix

--- a/members/B001277.yaml
+++ b/members/B001277.yaml
@@ -86,10 +86,12 @@ contact_form:
         selector: "#subject"
         value: "$SUBJECT"
         required: true
-      - name: comments
-        selector: "#comments"
-        value: "$MESSAGE"
-        required: true
+    - javascript:
+        - name: Message
+          selectors: [ "#comments" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          required: true
     - select:
       - name: salutation
         selector: "#salutation"

--- a/members/C000127.yaml
+++ b/members/C000127.yaml
@@ -49,9 +49,11 @@ contact_form:
         selector: input#input-0947E235-5056-A066-60AC-246CC0918F23
         value: $SUBJECT
         required: true
-      - name: message
-        selector: textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2
-        value: $MESSAGE
+    - javascript:
+      - name: Message
+        selectors: [ "textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - wait:
       - value: 1

--- a/members/C001056.yaml
+++ b/members/C001056.yaml
@@ -45,7 +45,7 @@ contact_form:
       - name: Message
         selectors: [ "textarea#edit-submitted-message" ]
         values: [ "$MESSAGE" ]
-        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+        commands: [ "elements[0].value = values[0].replace(/\\-\\-/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - find:
       - selector: select#edit-submitted-issue

--- a/members/C001056.yaml
+++ b/members/C001056.yaml
@@ -41,12 +41,12 @@ contact_form:
         selector: input#edit-submitted-email-address
         value: $EMAIL
         required: true
+    - javascript:
       - name: Message
-        selector: textarea#edit-submitted-message
-        value: $MESSAGE
+        selectors: [ "textarea#edit-submitted-message" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
-        options:
-          blacklist: "/\\-\\-/"
     - find:
       - selector: select#edit-submitted-issue
     - select:

--- a/members/C001075.yaml
+++ b/members/C001075.yaml
@@ -50,10 +50,12 @@ contact_form:
         selector: "#input-AB721CE8-4040-F985-52CD-9E550E8A76AA"
         value: $EMAIL
         required: true
-      - name: message
-        selector: "#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51"
-        value: $MESSAGE
-        required: true
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          required: true
     - select:
       - name: prefix
         selector: "#input-AB59F08A-4040-F985-52CD-7633AA11C65E"

--- a/members/D000563.yaml
+++ b/members/D000563.yaml
@@ -97,7 +97,7 @@ contact_form:
         - name: Message
           selectors: [ "#message" ]
           values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          commands: [ "elements[0].value = values[0].replace(/[\\%]/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: salutation

--- a/members/D000563.yaml
+++ b/members/D000563.yaml
@@ -93,12 +93,12 @@ contact_form:
           selector: "#subjecttext"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
-          options:
-            blacklist: "%"
     - select:
         - name: salutation
           selector: "#salutation"

--- a/members/D000607.yaml
+++ b/members/D000607.yaml
@@ -112,10 +112,12 @@ contact_form:
         selector: "#messagesubject"
         value: "$SUBJECT"
         required: true
-      - name: message
-        selector: "#message"
-        value: "$MESSAGE"
-        required: true
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          required: true
     - select:
       - name: salutation
         selector: "#salutation"

--- a/members/D000622.yaml
+++ b/members/D000622.yaml
@@ -117,9 +117,11 @@ contact_form:
           selector: input#input-356E5DA0-5056-A066-60C3-EF69B2E21E53
           value: $SUBJECT
           required: true
-        - name: message
-          selector: textarea#input-356E5E00-5056-A066-603C-9FAC0F3B6888
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#input-356E5E00-5056-A066-603C-9FAC0F3B6888" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - click_on:
         - selector: input[type='submit'][value='Submit']

--- a/members/F000444.yaml
+++ b/members/F000444.yaml
@@ -43,9 +43,11 @@ contact_form:
           selector: input#field_73AFA19A-4375-49C3-B145-A618657C8EE8
           value: $SUBJECT
           required: true
-        - name: MessageBody
-          selector: textarea#field_11C08DB8-4BD8-4CB6-BCC5-BCC5F4EB85B4
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#field_11C08DB8-4BD8-4CB6-BCC5-BCC5F4EB85B4" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: Prefix

--- a/members/G000386.yaml
+++ b/members/G000386.yaml
@@ -45,9 +45,11 @@ contact_form:
           selector: "#subject"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: prefix

--- a/members/G000555.yaml
+++ b/members/G000555.yaml
@@ -41,12 +41,12 @@ contact_form:
           selector: input#input-413A1B60-A672-8A13-9552-69CB2032BE16
           value: $PHONE
           required: true
-        - name: comments
-          selector: textarea#input-4154995F-09DE-911F-DD8B-93796597BB52
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#input-4154995F-09DE-911F-DD8B-93796597BB52" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
-          options:
-            blacklist: "*"
     - select:
         - name: prefix
           selector: select#input-41379D3E-BA76-1EEF-C6C5-C18565BAA26C

--- a/members/G000555.yaml
+++ b/members/G000555.yaml
@@ -45,7 +45,7 @@ contact_form:
         - name: Message
           selectors: [ "textarea#input-4154995F-09DE-911F-DD8B-93796597BB52" ]
           values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          commands: [ "elements[0].value = values[0].replace(/[\\*]/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: prefix

--- a/members/G000562.yaml
+++ b/members/G000562.yaml
@@ -56,9 +56,11 @@ contact_form:
           selector: "#input-86DBF4F8-5056-A066-6002-11D52792140B"
           value: $SUBJECT
           required: true
-        - name: "message"
-          selector: "#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: "prefix"

--- a/members/H001042.yaml
+++ b/members/H001042.yaml
@@ -45,9 +45,11 @@ contact_form:
         selector: input#input-12E6845B-D83C-EBAC-69D8-8880243D4E21
         value: $SUBJECT
         required: false
-      - name: message
-        selector: textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2
-        value: $MESSAGE
+    - javascript:
+      - name: Message
+        selectors: [ "textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - select:
       - name: title

--- a/members/H001075.yaml
+++ b/members/H001075.yaml
@@ -53,7 +53,7 @@ contact_form:
         - name: Message
           selectors: [ "textarea#input-6772B6F9-DC60-985A-DA90-CE9C6D99704B" ]
           values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          commands: [ "elements[0].value = values[0].replace(/[\\-]/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: prefix

--- a/members/H001075.yaml
+++ b/members/H001075.yaml
@@ -49,12 +49,12 @@ contact_form:
           selector: "#input-8896A1BE-5056-A066-604F-3010D7864A7D"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#input-6772B6F9-DC60-985A-DA90-CE9C6D99704B"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#input-6772B6F9-DC60-985A-DA90-CE9C6D99704B" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
-          options:
-            blacklist: "-"
     - select:
         - name: prefix
           selector: "#input-674234EB-FE2E-E1D2-DA0B-544DB1E29219"

--- a/members/I000055.yaml
+++ b/members/I000055.yaml
@@ -54,11 +54,11 @@ contact_form:
         options:
           max_length: 10000
     - javascript:
-        - name: Message
-          selectors: [ "textarea#field_4BBB4940-5FA9-43E1-9F05-0A9EB169C378" ]
-          values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
-          required: true
+      - name: Message
+        selectors: [ "textarea#field_4BBB4940-5FA9-43E1-9F05-0A9EB169C378" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = elements[0].value.replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+        required: true
     - select:
       - name: topic
         selector: select#field_158B2B90-6381-4626-BEEB-7B43C917BE66

--- a/members/I000055.yaml
+++ b/members/I000055.yaml
@@ -53,6 +53,12 @@ contact_form:
         required: true
         options:
           max_length: 10000
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#field_4BBB4940-5FA9-43E1-9F05-0A9EB169C378" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          required: true
     - select:
       - name: topic
         selector: select#field_158B2B90-6381-4626-BEEB-7B43C917BE66

--- a/members/M000639.yaml
+++ b/members/M000639.yaml
@@ -90,9 +90,11 @@ contact_form:
           selector: "#verify_email"
           value: $EMAIL
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: salutation

--- a/members/M001111.yaml
+++ b/members/M001111.yaml
@@ -114,7 +114,7 @@ contact_form:
       - name: Message
         selectors: [ "#message" ]
         values: [ "$MESSAGE" ]
-        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+        commands: [ "elements[0].value = values[0].replace(/[\\•]/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - click_on:
       - selector: form.uniForm input[type=submit]

--- a/members/M001111.yaml
+++ b/members/M001111.yaml
@@ -110,12 +110,12 @@ contact_form:
         selector: input#field_250A9CB8-13DC-40F7-94FB-D301593DB4C9
         value: $SUBJECT
         required: true
-      - name: message
-        selector: textarea#field_5722C424-8601-4ABF-A8D1-AC11B9C45F87
-        value: $MESSAGE
+    - javascript:
+      - name: Message
+        selectors: [ "#message" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
-        options:
-          blacklist: "•"
     - click_on:
       - selector: form.uniForm input[type=submit]
   success:

--- a/members/M001169.yaml
+++ b/members/M001169.yaml
@@ -99,9 +99,11 @@ contact_form:
           selector: "#subject"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: salutation

--- a/members/M001170.yaml
+++ b/members/M001170.yaml
@@ -6,6 +6,8 @@ contact_form:
     - visit: "http://www.mccaskill.senate.gov/contact#contactForm"
     - click_on:
         - selector: "a[href='#contactForm']"
+    - wait:
+        - value: 1
     - fill_in:
         - name: fname
           selector: "#fname"
@@ -51,9 +53,11 @@ contact_form:
           selector: "#subject"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: salutation

--- a/members/M001176.yaml
+++ b/members/M001176.yaml
@@ -54,9 +54,11 @@ contact_form:
           selector: "#verify_email"
           value: $EMAIL
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: salutation

--- a/members/P000449.yaml
+++ b/members/P000449.yaml
@@ -47,9 +47,11 @@ contact_form:
           selector: input#field_06A8C75E-4922-470D-ACFF-44367138678C
           value: $SUBJECT
           required: true
-        - name: message
-          selector: textarea#field_716E154B-9C67-4EDE-97AC-A867C5556908
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#field_716E154B-9C67-4EDE-97AC-A867C5556908" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: topic

--- a/members/P000595.yaml
+++ b/members/P000595.yaml
@@ -62,9 +62,11 @@ contact_form:
           selector: "#input-93E136F1-4040-F985-52CD-D4EB6A849AA3"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: topic

--- a/members/S000148.yaml
+++ b/members/S000148.yaml
@@ -56,9 +56,11 @@ contact_form:
           selector: "#subjecttext"
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
-          value: $MESSAGE
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: prefix

--- a/members/S000770.yaml
+++ b/members/S000770.yaml
@@ -49,9 +49,11 @@ contact_form:
         selector: "#input-F81BE935-4040-F985-52CD-D2815240A234"
         value: $SUBJECT
         required: true
-      - name: message
-        selector: "#input-F80AC5B6-4040-F985-52CD-834C1DD62DF3"
-        value: $MESSAGE
+    - javascript:
+      - name: Message
+        selectors: [ "textarea#input-F80AC5B6-4040-F985-52CD-834C1DD62DF3" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - click_on:
       - value: Submit

--- a/members/T000476.yaml
+++ b/members/T000476.yaml
@@ -37,9 +37,11 @@ contact_form:
         selector: "#field_E2D2548D-F3B7-48F7-9BD0-E29F4ED82A43"
         value: $SUBJECT
         required: true
-      - name: "message"
-        selector: "#field_279EFB03-F78D-4924-8599-F04AEB99A7A6"
-        value: $MESSAGE
+    - javascript:
+      - name: Message
+        selectors: [ "textarea#field_279EFB03-F78D-4924-8599-F04AEB99A7A6" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - select:
       - name: "prefix"

--- a/members/W000779.yaml
+++ b/members/W000779.yaml
@@ -39,10 +39,12 @@ contact_form:
         selector: "#contactForm #verify_email"
         value: $EMAIL
         required: true
-      - name: message
-        selector: "#contactForm #message"
-        value: $MESSAGE
-        required: true
+    - javascript:
+        - name: Message
+          selectors: [ "#message" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          required: true
     - select:
       - name: salutation
         selector: "#contactForm select#salutation"

--- a/members/W000817.yaml
+++ b/members/W000817.yaml
@@ -46,9 +46,11 @@ contact_form:
         selector: input#subject
         value: "$SUBJECT"
         required: true
-      - name: messageBody
-        selector: textarea#msgbody
-        value: "$MESSAGE"
+    - javascript:
+      - name: Message
+        selectors: [ "textarea#msgbody" ]
+        values: [ "$MESSAGE" ]
+        commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
         required: true
     - select:
       - name: Prefix

--- a/members/Y000064.yaml
+++ b/members/Y000064.yaml
@@ -55,6 +55,12 @@ contact_form:
           required: true
           options:
             blacklist: "/\\-\\-/"
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2" ]
+          values: [ "$MESSAGE" ]
+          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          required: true
     - select:
         - name: prefix
           selector: select#input-B03E0527-4040-F985-52CD-C0DD6BEF325F

--- a/members/Y000064.yaml
+++ b/members/Y000064.yaml
@@ -49,17 +49,11 @@ contact_form:
           selector: input#input-78803FD6-BD54-3C62-213B-D4FBABCB2E0C
           value: $SUBJECT
           required: true
-        - name: message
-          selector: textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2
-          value: $MESSAGE
-          required: true
-          options:
-            blacklist: "/\\-\\-/"
     - javascript:
         - name: Message
           selectors: [ "textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2" ]
           values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = values[0].replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          commands: [ "elements[0].value = values[0].replace(/\\-\\-/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
           required: true
     - select:
         - name: prefix


### PR DESCRIPTION
Several US Sen yamls are failing due to a message a client sent with a youtube link with special characters. This PR adds a JavaScript step to these yamls to change the bad url with a url that would allow the message to be delivered. This would decrease the amount of messages in Dispatcher in the retry queue. 

Note: These are 31 yamls for US Senators. These 31 are the ones showing up on LogEntries as failing. I'm not quite sure all 100 US Sen yamls were affected by this issue. Nevertheless, I will continue to take a look at LogEntries and update any new yaml that presents this problem. 

 