### PR TITLE
Update MD state yamls

### DIFF
--- a/members/MDL000190.yaml
+++ b/members/MDL000190.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000192.yaml
+++ b/members/MDL000192.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000194.yaml
+++ b/members/MDL000194.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000195.yaml
+++ b/members/MDL000195.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000196.yaml
+++ b/members/MDL000196.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000199.yaml
+++ b/members/MDL000199.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000211.yaml
+++ b/members/MDL000211.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000212.yaml
+++ b/members/MDL000212.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000213.yaml
+++ b/members/MDL000213.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000215.yaml
+++ b/members/MDL000215.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000218.yaml
+++ b/members/MDL000218.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000219.yaml
+++ b/members/MDL000219.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000220.yaml
+++ b/members/MDL000220.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000221.yaml
+++ b/members/MDL000221.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000224.yaml
+++ b/members/MDL000224.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000225.yaml
+++ b/members/MDL000225.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000226.yaml
+++ b/members/MDL000226.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000230.yaml
+++ b/members/MDL000230.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000232.yaml
+++ b/members/MDL000232.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000233.yaml
+++ b/members/MDL000233.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000236.yaml
+++ b/members/MDL000236.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000238.yaml
+++ b/members/MDL000238.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000239.yaml
+++ b/members/MDL000239.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000240.yaml
+++ b/members/MDL000240.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000241.yaml
+++ b/members/MDL000241.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000244.yaml
+++ b/members/MDL000244.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000245.yaml
+++ b/members/MDL000245.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000246.yaml
+++ b/members/MDL000246.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000247.yaml
+++ b/members/MDL000247.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000248.yaml
+++ b/members/MDL000248.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000252.yaml
+++ b/members/MDL000252.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000255.yaml
+++ b/members/MDL000255.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000257.yaml
+++ b/members/MDL000257.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000264.yaml
+++ b/members/MDL000264.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000267.yaml
+++ b/members/MDL000267.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000270.yaml
+++ b/members/MDL000270.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000272.yaml
+++ b/members/MDL000272.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000275.yaml
+++ b/members/MDL000275.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000277.yaml
+++ b/members/MDL000277.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000278.yaml
+++ b/members/MDL000278.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000279.yaml
+++ b/members/MDL000279.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000281.yaml
+++ b/members/MDL000281.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000282.yaml
+++ b/members/MDL000282.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000284.yaml
+++ b/members/MDL000284.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000285.yaml
+++ b/members/MDL000285.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000290.yaml
+++ b/members/MDL000290.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000293.yaml
+++ b/members/MDL000293.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000294.yaml
+++ b/members/MDL000294.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000295.yaml
+++ b/members/MDL000295.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000298.yaml
+++ b/members/MDL000298.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000301.yaml
+++ b/members/MDL000301.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000303.yaml
+++ b/members/MDL000303.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000304.yaml
+++ b/members/MDL000304.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000306.yaml
+++ b/members/MDL000306.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000309.yaml
+++ b/members/MDL000309.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000311.yaml
+++ b/members/MDL000311.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000312.yaml
+++ b/members/MDL000312.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000315.yaml
+++ b/members/MDL000315.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000316.yaml
+++ b/members/MDL000316.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000321.yaml
+++ b/members/MDL000321.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000322.yaml
+++ b/members/MDL000322.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000323.yaml
+++ b/members/MDL000323.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000324.yaml
+++ b/members/MDL000324.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000325.yaml
+++ b/members/MDL000325.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000327.yaml
+++ b/members/MDL000327.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000328.yaml
+++ b/members/MDL000328.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000332.yaml
+++ b/members/MDL000332.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000335.yaml
+++ b/members/MDL000335.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000337.yaml
+++ b/members/MDL000337.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000341.yaml
+++ b/members/MDL000341.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000342.yaml
+++ b/members/MDL000342.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000344.yaml
+++ b/members/MDL000344.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000345.yaml
+++ b/members/MDL000345.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000349.yaml
+++ b/members/MDL000349.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000354.yaml
+++ b/members/MDL000354.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000359.yaml
+++ b/members/MDL000359.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000361.yaml
+++ b/members/MDL000361.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000368.yaml
+++ b/members/MDL000368.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000370.yaml
+++ b/members/MDL000370.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000371.yaml
+++ b/members/MDL000371.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000373.yaml
+++ b/members/MDL000373.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000374.yaml
+++ b/members/MDL000374.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000379.yaml
+++ b/members/MDL000379.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000387.yaml
+++ b/members/MDL000387.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000388.yaml
+++ b/members/MDL000388.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000391.yaml
+++ b/members/MDL000391.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000393.yaml
+++ b/members/MDL000393.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000394.yaml
+++ b/members/MDL000394.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000395.yaml
+++ b/members/MDL000395.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000396.yaml
+++ b/members/MDL000396.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000398.yaml
+++ b/members/MDL000398.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000399.yaml
+++ b/members/MDL000399.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000400.yaml
+++ b/members/MDL000400.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000401.yaml
+++ b/members/MDL000401.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000403.yaml
+++ b/members/MDL000403.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000404.yaml
+++ b/members/MDL000404.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000406.yaml
+++ b/members/MDL000406.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000407.yaml
+++ b/members/MDL000407.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000408.yaml
+++ b/members/MDL000408.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000409.yaml
+++ b/members/MDL000409.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000412.yaml
+++ b/members/MDL000412.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000413.yaml
+++ b/members/MDL000413.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000415.yaml
+++ b/members/MDL000415.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000416.yaml
+++ b/members/MDL000416.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000605.yaml
+++ b/members/MDL000605.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000617.yaml
+++ b/members/MDL000617.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000618.yaml
+++ b/members/MDL000618.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000619.yaml
+++ b/members/MDL000619.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000620.yaml
+++ b/members/MDL000620.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000621.yaml
+++ b/members/MDL000621.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000622.yaml
+++ b/members/MDL000622.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000624.yaml
+++ b/members/MDL000624.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000625.yaml
+++ b/members/MDL000625.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000628.yaml
+++ b/members/MDL000628.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000630.yaml
+++ b/members/MDL000630.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000631.yaml
+++ b/members/MDL000631.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000632.yaml
+++ b/members/MDL000632.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000634.yaml
+++ b/members/MDL000634.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000635.yaml
+++ b/members/MDL000635.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000637.yaml
+++ b/members/MDL000637.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000638.yaml
+++ b/members/MDL000638.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000640.yaml
+++ b/members/MDL000640.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000643.yaml
+++ b/members/MDL000643.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000644.yaml
+++ b/members/MDL000644.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000645.yaml
+++ b/members/MDL000645.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000646.yaml
+++ b/members/MDL000646.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000647.yaml
+++ b/members/MDL000647.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000650.yaml
+++ b/members/MDL000650.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000651.yaml
+++ b/members/MDL000651.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000652.yaml
+++ b/members/MDL000652.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000655.yaml
+++ b/members/MDL000655.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000657.yaml
+++ b/members/MDL000657.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000658.yaml
+++ b/members/MDL000658.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000660.yaml
+++ b/members/MDL000660.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000661.yaml
+++ b/members/MDL000661.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000663.yaml
+++ b/members/MDL000663.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000664.yaml
+++ b/members/MDL000664.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000665.yaml
+++ b/members/MDL000665.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000666.yaml
+++ b/members/MDL000666.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000667.yaml
+++ b/members/MDL000667.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000668.yaml
+++ b/members/MDL000668.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000670.yaml
+++ b/members/MDL000670.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000671.yaml
+++ b/members/MDL000671.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000672.yaml
+++ b/members/MDL000672.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000673.yaml
+++ b/members/MDL000673.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000674.yaml
+++ b/members/MDL000674.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000675.yaml
+++ b/members/MDL000675.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000680.yaml
+++ b/members/MDL000680.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000681.yaml
+++ b/members/MDL000681.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000682.yaml
+++ b/members/MDL000682.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000683.yaml
+++ b/members/MDL000683.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000684.yaml
+++ b/members/MDL000684.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000685.yaml
+++ b/members/MDL000685.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000686.yaml
+++ b/members/MDL000686.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000687.yaml
+++ b/members/MDL000687.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000688.yaml
+++ b/members/MDL000688.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000689.yaml
+++ b/members/MDL000689.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000690.yaml
+++ b/members/MDL000690.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000691.yaml
+++ b/members/MDL000691.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000692.yaml
+++ b/members/MDL000692.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000693.yaml
+++ b/members/MDL000693.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000695.yaml
+++ b/members/MDL000695.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000696.yaml
+++ b/members/MDL000696.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000697.yaml
+++ b/members/MDL000697.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000699.yaml
+++ b/members/MDL000699.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000700.yaml
+++ b/members/MDL000700.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000703.yaml
+++ b/members/MDL000703.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000716.yaml
+++ b/members/MDL000716.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000718.yaml
+++ b/members/MDL000718.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000719.yaml
+++ b/members/MDL000719.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]

--- a/members/MDL000720.yaml
+++ b/members/MDL000720.yaml
@@ -33,6 +33,10 @@ contact_form:
         selector: "#ctlContactLegislator_txtMessage"
         value: $MESSAGE
         required: true
+      - name: Phone Number
+        selector: "input#ctlContactLegislator_txtPhoneNumber"
+        value: $PHONE
+        required: true
     - javascript:
       - name: phone
         selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]


### PR DESCRIPTION
Updating these yamls with a PHONE value before the JS step. This would ensure the required phone number step is not omitted when the supporter is filling out these yamls, as is currently happening. 