### PR TITLE
US Sen Mccaskill yaml update

### DIFF
--- a/members/M001170.yaml
+++ b/members/M001170.yaml
@@ -13,6 +13,8 @@ contact_form:
           selector: "#fname"
           value: $NAME_FIRST
           required: true
+          options:
+            blacklist: "."
         - name: lname
           selector: "#lname"
           value: $NAME_LAST


### PR DESCRIPTION
Quick fix to blacklist periods ( . ) from the first name. McCaskill's form does not allow for chars other than letters in the first name input (see image attached). 

![image](https://user-images.githubusercontent.com/8680733/39444728-b4134608-4c86-11e8-8094-83d0fa2ec5e7.png)

