### PR TITLE
Update blacklist and Success Message

### DIFF
--- a/members/C000141.yaml
+++ b/members/C000141.yaml
@@ -50,7 +50,7 @@ contact_form:
         value: $MESSAGE
         required: true
         options:
-          blacklist: ":"
+          blacklist: ":_%&=-"
     - select:
       - name: prefix
         selector: select#input-B03E0527-4040-F985-52CD-C0DD6BEF325F
@@ -107,4 +107,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: "Your message has been received by my office"
+      contains: "Email Ben"

--- a/members/V000128.yaml
+++ b/members/V000128.yaml
@@ -58,7 +58,7 @@ contact_form:
           value: $MESSAGE
           required: true
           options:
-            blacklist: "/\\-\\-/:"
+            blacklist: "/\\-\\-/:_%&="
     - select:
         - name: Prefix
           selector: select#input-B03E0527-4040-F985-52CD-C0DD6BEF325F


### PR DESCRIPTION
A supporter sent a message to these two senators with a link to a website that looked like this 

https://www.flickr.com/search/?user_id=63381646%40N02&sort=date-taken-desc&text=Lesser%20Prairie-chicken&view_all=1 

This message triggered the Senate security alert that shows up for weird chars in messages. I added a few more characters in the `blacklist` step to make sure the message is delivered. 