### PR TITLE
Blacklist Char

### DIFF
--- a/members/FMNS420b9c88.yaml
+++ b/members/FMNS420b9c88.yaml
@@ -46,7 +46,7 @@ contact_form:
         value: "$MESSAGE"
         required: true
         options:
-          blacklist: ":----"
+          blacklist: ":----—"
     - select:
       - name: Prefix
         selector: select#edit-submitted-constituent-information-prefix

--- a/members/S000148.yaml
+++ b/members/S000148.yaml
@@ -61,7 +61,7 @@ contact_form:
           value: $MESSAGE
           required: true
           options:
-            blacklist: ":"
+            blacklist: ":—"
     - javascript:
         - name: Message
           selectors: [ "#message" ]


### PR DESCRIPTION
Blacklisting '—' in these two yamls to test if this helps pinpoint the cause of the 'security risk' alert 