### PR TITLE
Create custom yaml

### DIFF
--- a/members/CusB94a1a75c1534267461.yaml
+++ b/members/CusB94a1a75c1534267461.yaml
@@ -1,0 +1,131 @@
+bioguide: CusB94a1a75c1534267461
+contact_form:
+  method: post
+  action: ""
+  steps:
+    - visit: "https://www.regulations.gov/comment?D=CEQ-2018-0001-0001"
+    - wait:
+      - value: 6
+    - find:
+      - selector: input#gwt-uid-164
+    - click_on:
+        - selector: input#gwt-uid-164
+    - wait:
+      - value: 1
+    - find:
+      - selector: textarea#x-auto-0-input
+    - fill_in:
+        - name: message
+          selector: textarea#x-auto-0-input
+          value: $MESSAGE
+          required: true
+        - name: First Name
+          selector: input#x-auto-1-input
+          value: $NAME_FIRST
+          required: true
+        - name: Last Name
+          selector: input#x-auto-2-input
+          value: $NAME_LAST
+          required: true
+    - click_on:
+        - selector: input#gwt-uid-85
+    - fill_in:
+        - name: City
+          selector: input#x-auto-5-input
+          value: $ADDRESS_CITY
+          required: false
+        - name: zip5
+          selector: input#x-auto-8-input
+          value: $ADDRESS_ZIP5
+          required: false
+        - name: email
+          selector: input#x-auto-10-input
+          value: $EMAIL
+          required: false
+        - name: phone
+          selector: input#x-auto-11-input
+          value: $PHONE
+          required: false
+    - select:
+        - name: state
+          selector: input#x-auto-6-input
+          value: $ADDRESS_STATE_FULL
+          required: false
+          options:
+            Alabama: Alabama
+            Alaska: Alaska
+            American Samoa: American Samoa
+            Arizona: Arizona
+            Arkansas: Arkansas
+            California: California
+            Colorado: Colorado
+            Connecticut: Connecticut
+            Delaware: Delaware
+            District of Columbia: District of Columbia
+            Florida: Florida
+            Georgia: Georgia
+            Guam: Guam
+            Hawaii: Hawaii
+            Idaho: Idaho
+            Illinois: Illinois
+            Indiana: Indiana
+            Iowa: Iowa
+            Kansas: Kansas
+            Kentucky: Kentucky
+            Louisiana: Louisiana
+            Maine: Maine
+            Maryland: Maryland
+            Massachusetts: Massachusetts
+            Michigan: Michigan
+            Minnesota: Minnesota
+            Mississippi: Mississippi
+            Missouri: Missouri
+            Montana: Montana
+            Nebraska: Nebraska
+            Nevada: Nevada
+            New Hampshire: New Hampshire
+            New Jersey: New Jersey
+            New Mexico: New Mexico
+            New York: New York
+            North Carolina: North Carolina
+            North Dakota: North Dakota
+            Northern Mariana Islands: Northern Mariana Islands
+            Ohio: Ohio
+            Oklahoma: Oklahoma
+            Oregon: Oregon
+            Pennsylvania: Pennsylvania
+            Puerto Rico: Puerto Rico
+            Rhode Island: Rhode Island
+            South Carolina: South Carolina
+            South Dakota: South Dakota
+            Tennessee: Tennessee
+            Texas: Texas
+            US Virgin Islands: US Virgin Islands
+            Utah: Utah
+            Vermont: Vermont
+            Virginia: Virginia
+            Washington: Washington
+            West Virginia: West Virginia
+            Wisconsin: Wisconsin
+            Wyoming: Wyoming
+    - click_on:
+        - selector: div.GIY1LSJISC button.primary
+    - wait:
+        - value: 3
+    - find:
+        - selector: input#gwt-uid-250
+    - click_on:
+        - selector: input#gwt-uid-250
+    - wait:
+        - value: 3
+    - find:
+        - selector: div.GIY1LSJERD button.primary
+    - click_on:
+        - selector: div.GIY1LSJERD button.primary
+    - wait:
+        - value: 6
+  success:
+    headers:
+      status: 200
+    body:
+      contains: "Your Comment Tracking Number"

--- a/members/CusB94a1a75c1534267461.yaml
+++ b/members/CusB94a1a75c1534267461.yaml
@@ -5,17 +5,17 @@ contact_form:
   steps:
     - visit: "https://www.regulations.gov/comment?D=CEQ-2018-0001-0001"
     - wait:
-      - value: 6
+        - value: 6
     - find:
-      - selector: input#gwt-uid-164
+        - selector: input#gwt-uid-164
     - click_on:
         - selector: input#gwt-uid-164
     - click_on:
         - selector: input#gwt-uid-85
     - wait:
-      - value: 1
+        - value: 1
     - find:
-      - selector: textarea#x-auto-0-input
+        - selector: textarea#x-auto-0-input
     - fill_in:
         - name: message
           selector: textarea#x-auto-0-input
@@ -29,7 +29,6 @@ contact_form:
           selector: input#x-auto-2-input
           value: $NAME_LAST
           required: true
-    - fill_in:
         - name: City
           selector: input#x-auto-5-input
           value: $ADDRESS_CITY

--- a/members/CusB94a1a75c1534267461.yaml
+++ b/members/CusB94a1a75c1534267461.yaml
@@ -10,6 +10,8 @@ contact_form:
       - selector: input#gwt-uid-164
     - click_on:
         - selector: input#gwt-uid-164
+    - click_on:
+        - selector: input#gwt-uid-85
     - wait:
       - value: 1
     - find:
@@ -27,8 +29,6 @@ contact_form:
           selector: input#x-auto-2-input
           value: $NAME_LAST
           required: true
-    - click_on:
-        - selector: input#gwt-uid-85
     - fill_in:
         - name: City
           selector: input#x-auto-5-input


### PR DESCRIPTION
FYI: Notice the first `find` and `click-on` combo in the yaml. This form loads with the " I am submitting on behalf of a third party" input already selected 
[![Screenshot from Gyazo](https://gyazo.com/eb9495e4cd2e8e03e549dce664e65b93/raw)](https://gyazo.com/eb9495e4cd2e8e03e549dce664e65b93)

Hence why I included that `find` and `click-on`, to make sure Organization Name is not a required field. 

I also increased the final wait time from 5 to 6 seconds, as previous errors with regs.gov custom targets have shown screenies that fail to completely load after the submit button has been clicked. 