### PR TITLE
Editing couple of state yamls

### DIFF
--- a/members/CTL000045.yaml
+++ b/members/CTL000045.yaml
@@ -46,4 +46,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: Thank you for your message
+      contains: Thank you for your web contact.

--- a/members/PAL000530.yaml
+++ b/members/PAL000530.yaml
@@ -3,7 +3,7 @@ contact_form:
   method: post
   action: ""
   steps:
-    - visit: http://wpcontact.pasenategop.com/contact.aspx?websiteid=37
+    - visit: "http://wpcontact.pasenategop.com/contact.aspx?websiteid=37"
     - find:
         - selector: "#txtFirstname"
     - fill_in:
@@ -43,6 +43,11 @@ contact_form:
           selector: "#txtComments"
           value: $MESSAGE
           required: true
+    - javascript:
+        - name: phone
+          selectors: [ "#txtPhone"]
+          values: [ "$PHONE" ]
+          commands: [ "elements[0].value = values[0].length < 10 ? values[0] + '0' : values[0]" ]
     - select:
         - name: topic
           selector: "#ddlIssue_Input"


### PR DESCRIPTION
- CTL000045: update success message
- PAL000530: submissions to this form are currently failing due to the phone number input. On submissions, form cuts first digit of phone number. I was able to replicate the issue but not really figure out why it was happening. Added a JS step that hardcodes a 0 at the beginning of the phone number that eventually gets cut out, thus allowing the correct number to be added to the form. 

PS: Tommy thinks this is not a proper fix. No other PA targets are presenting this issue atm. If more show up, I'll work on a more permanent/better fix. 