### PR TITLE
Senate updates

### DIFF
--- a/members/P000612.yaml
+++ b/members/P000612.yaml
@@ -264,4 +264,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: "We will contact you"
+      contains: "We will contact you if we need any additional information."

--- a/members/S000148.yaml
+++ b/members/S000148.yaml
@@ -5,13 +5,13 @@ contact_form:
   steps:
     - visit: "https://www.schumer.senate.gov/contact/email-chuck"
     - wait:
-        - value: 1
+        - value: 2
     - find:
         - selector: a[type='button'][class='close']
     - click_on:
         - selector: a[type='button'][class='close']
     - wait:
-        - value: 1
+        - value: 2
     - find:
         - selector: select#actions
     - select:
@@ -22,7 +22,7 @@ contact_form:
           options:
             Share your opinion or comments on bills or other issues: Share your opinion or comments on bills or other issues
     - wait:
-        - value: 3
+        - value: 2
     - find:
         - selector: "#fname"
     - fill_in:
@@ -121,6 +121,8 @@ contact_form:
             Transportation: Transportation
             Veterans: Veterans
             Other: Other
+    - wait:
+        - value: 1
     - click_on:
         - value: Send
           selector: div#content input#side-search-btn

--- a/members/S000148.yaml
+++ b/members/S000148.yaml
@@ -5,7 +5,7 @@ contact_form:
   steps:
     - visit: "https://www.schumer.senate.gov/contact/email-chuck"
     - wait:
-        - value: 2
+        - value: 4
     - find:
         - selector: a[type='button'][class='close']
     - click_on:

--- a/members/S000148.yaml
+++ b/members/S000148.yaml
@@ -42,6 +42,9 @@ contact_form:
           selector: input#mailing_streetAddress2
           value: $ADDRESS_STREET_2
           required: false
+    - click_on:
+        - selector: a[type='button'][class='close']
+    - fill_in:
         - name: city
           selector: "#mailing_city"
           value: $ADDRESS_CITY
@@ -50,6 +53,9 @@ contact_form:
           selector: "#mailing_zipCode"
           value: $ADDRESS_ZIP5
           required: true
+    - click_on:
+        - selector: a[type='button'][class='close']
+    - fill_in:
         - name: phone
           selector: "#home_phone_number"
           value: $PHONE


### PR DESCRIPTION
S000148: 
- I did a little bit more digging into why retries have been failing. In the error screenies I was seeing (example below), looking a little bit closer, you could actually see that some of the form's inputs like Name, Last Name and Address were filled out before the error occurred. Although I couldn't reproduce this error, it looks like, in a few instances, the pop-up notification showed up after the form was loaded when some inputs were being filled out. As such, I slightly increased the `wait` step at the beginning of the yaml to give it a bit more time to the pop-up to show up. I also added a final `wait`, as the form was a bit slow after clicking the submit button.  

[![Screenshot from Gyazo](https://gyazo.com/afc61fc95d01bbc2eac39335bc82cf55/raw)](https://gyazo.com/afc61fc95d01bbc2eac39335bc82cf55)

P000612:

- I checked and double-checked the text in the success message and it is fine. Did a bunch of testing to see if I could get an error but was unable to reproduce. Not really sure why we're getting errors saying that the text does not meet the success criteria. Anyhow, I added the whole string in the Thank You page to see if this does the trick.  

[![Screenshot from Gyazo](https://gyazo.com/3febdab8be39d447337d161c57806e8f/raw)](https://gyazo.com/3febdab8be39d447337d161c57806e8f)