### PR TITLE
Create custom target (VAN-64289); Add wait time to similar custom target

### DIFF
--- a/members/CusCb5e6eb5c1541443560.yaml
+++ b/members/CusCb5e6eb5c1541443560.yaml
@@ -1,9 +1,9 @@
-bioguide: CusD81cffe90CusD81cffe90
+bioguide: CusCb5e6eb5c1541443560
 contact_form:
   method: post
   action: ""
   steps:
-    - visit: "https://www.regulations.gov/comment?D=USCIS-2010-0012-0001"
+    - visit: "https://www.regulations.gov/comment?D=DHS_FRDOC_0001-1706"
     - wait:
       - value: 6
     - find:


### PR DESCRIPTION
RE Add wait:

- I noted several screenshots of successful msgs just had part, but not all, of the information provided by supporters. Although the missing info was optional, that's still should be part of the message if provided. I noticed that the problem was not enough time for that part of the form to load properly (after clicking this button, `selector: input#gwt-uid-85`). Adding 1 sec value there worked. Added that to this yaml, CusD81cffe90CusD81cffe90, as well. 

