### PR TITLE
Add wait after Category step

### DIFF
--- a/members/CusM4b1cb3821543517908.yaml
+++ b/members/CusM4b1cb3821543517908.yaml
@@ -104,6 +104,8 @@ contact_form:
           selector: input#x-auto-20-input
           value: Individual
           required: true
+    - wait:
+        - value: 1
     - click_on:
         - selector: div.GIY1LSJISC button.primary
     - wait:


### PR DESCRIPTION
I'm currently seeing the below error in the Category field for this custom target (please note that I deleted supporter info from the screenshot) 

![image](https://user-images.githubusercontent.com/8680733/51052493-d68e9880-15a4-11e9-9989-86c537b6022d.png)


I initially thought it was related to a `selector` issue, maybe it being randomly changed every time the page loaded.  I checked it and found that was not the case. So now I'm a little bit more convinced is due to a timing issue. My theory is that when "Individual" is selected as part of the `Category` step, there should be a small wait before clicking on Continue for step 2 of this regs.gov form. Tests with the added `wait` succeeded. 