### PR TITLE
Small edit to fix wrong bioguide

### DIFF
--- a/members/SCOG21f28540.yaml
+++ b/members/SCOG21f28540.yaml
@@ -1,4 +1,4 @@
-bioguide: SCOG21f28540
+bioguide: SCOGe704c3de
 contact_form:
   method: post
   action: ""


### PR DESCRIPTION
The yaml of CO Gov had the wrong bio ID. I can't recall where I took the wrong bioID from, as it's not present in Artemis, my local repo of contact-congress, appinsights, you name it.  But I'm sure I didn't just made it up. This will haunt me until I figure it out. 