### PR TITLE
Update selectors; add chrome to MI yamls

### DIFF
--- a/members/MIL000087.yaml
+++ b/members/MIL000087.yaml
@@ -44,7 +44,7 @@ contact_form:
           required: true
     - click_on:
         - value: Submit
-          selector: button.button
+          selector: button.button.is-form-button
     - wait:
         - value: 2
     - find:

--- a/members/MIL000087.yaml
+++ b/members/MIL000087.yaml
@@ -2,54 +2,55 @@ bioguide: MIL000087
 contact_form:
   method: post
   action:
+  useChrome: true
   steps:
     - visit: "http://senatedems.com/ananich/contact/"
     - fill_in:
-        - name: fname
-          selector: "#fname"
+        - name: First Name
+          selector: input[name='contact.fname']
           value: $NAME_FIRST
           required: true
-        - name: lname
-          selector: "#lname"
+        - name: Last Name
+          selector: input[name='contact.lname']
           value: $NAME_LAST
           required: true
         - name: email
-          selector: "#email"
+          selector: input[name='contact.email']
           value: $EMAIL
           required: true
-        - name: address
-          selector: "#address"
+        - name: Address
+          selector: input[name='contact.addr']
           value: $ADDRESS_STREET
           required: true
-        - name: city
-          selector: "#city"
+        - name: City
+          selector: input[name='contact.city']
           value: $ADDRESS_CITY
           required: true
         - name: zip
-          selector: "#zip"
+          selector: input[name='contact.zip']
           value: $ADDRESS_ZIP5
           required: true
-        - name: phone
-          selector: "#phone"
+        - name: Phone
+          selector: input[name='contact.phone']
           value: $PHONE
           required: true
-        - name: subject
-          selector: "#subject"
+        - name: Subject
+          selector: input[name='contact.subject']
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
+        - name: Message
+          selector: textarea[name='contact.message']
           value: $MESSAGE
           required: true
     - click_on:
-        - value: DoNotSubscribe
-          selector: "#subscribe"
         - value: Submit
-          selector: "input[type='submit'][value='Send']"
+          selector: button.button
+    - wait:
+        - value: 2
     - find:
-        - selector: ".alert-info"
+        - selector: div span.highlighted
   success:
     headers:
       status: 200
     body:
-      contains: Message sent
+      contains: Thank you!

--- a/members/MIL000302.yaml
+++ b/members/MIL000302.yaml
@@ -2,54 +2,55 @@ bioguide: MIL000302
 contact_form:
   method: post
   action:
+  useChrome: true
   steps:
     - visit: "http://senatedems.com/hertel/contact/"
     - fill_in:
-        - name: fname
-          selector: "#fname"
+        - name: First Name
+          selector: input[name='contact.fname']
           value: $NAME_FIRST
           required: true
-        - name: lname
-          selector: "#lname"
+        - name: Last Name
+          selector: input[name='contact.lname']
           value: $NAME_LAST
           required: true
         - name: email
-          selector: "#email"
+          selector: input[name='contact.email']
           value: $EMAIL
           required: true
-        - name: address
-          selector: "#address"
+        - name: Address
+          selector: input[name='contact.addr']
           value: $ADDRESS_STREET
           required: true
-        - name: city
-          selector: "#city"
+        - name: City
+          selector: input[name='contact.city']
           value: $ADDRESS_CITY
           required: true
         - name: zip
-          selector: "#zip"
+          selector: input[name='contact.zip']
           value: $ADDRESS_ZIP5
           required: true
-        - name: phone
-          selector: "#phone"
+        - name: Phone
+          selector: input[name='contact.phone']
           value: $PHONE
           required: true
-        - name: subject
-          selector: "#subject"
+        - name: Subject
+          selector: input[name='contact.subject']
           value: $SUBJECT
           required: true
-        - name: message
-          selector: "#message"
+        - name: Message
+          selector: textarea[name='contact.message']
           value: $MESSAGE
           required: true
     - click_on:
-        - value: DoNotSubscribe
-          selector: "#subscribe"
         - value: Submit
-          selector: "input[type='submit'][value='Send']"
+          selector: button.button
+    - wait:
+        - value: 2
     - find:
-        - selector: ".alert-info"
+        - selector: div span.highlighted
   success:
     headers:
       status: 200
     body:
-      contains: Message sent
+      contains: Thank you!

--- a/members/MIL000302.yaml
+++ b/members/MIL000302.yaml
@@ -44,7 +44,7 @@ contact_form:
           required: true
     - click_on:
         - value: Submit
-          selector: button.button
+          selector: button.button.is-form-button
     - wait:
         - value: 2
     - find:

--- a/members/TXL000480.yaml
+++ b/members/TXL000480.yaml
@@ -37,6 +37,10 @@ contact_form:
           selector: "input[name='email']"
           value: $EMAIL
           required: true
+        - name: subject
+          selector: "input[name='subject']"
+          value: $TOPIC
+          required: true
         - name: message
           selector: "textarea[name='message']"
           value: $MESSAGE
@@ -54,35 +58,6 @@ contact_form:
             Rev: Rev
             Fr: Fr
             Dr: Dr
-        - name: subject
-          selector: "select[name='subject']"
-          value: $TOPIC
-          required: true
-          options:
-            - Agriculture
-            - Child Protective Services (CPS)
-            - Child Support
-            - CHIP
-            - Education
-            - Energy
-            - Higher Education
-            - Historical Commission
-            - Housing/community affairs
-            - Hunting/sporting issues
-            - Immigration
-            - Insurance
-            - Licensing/regulation
-            - Medicaid
-            - Medical
-            - Natural Resources
-            - Public Safety
-            - Scheduling
-            - Taxes/ Appraisal district
-            - TCEQ (environment)
-            - Trans-Texas Corridor
-            - TX Workforce/employment issues
-            - TXDoT
-            - Utilities
     - click_on:
         - value: Send Message
           selector: "#email-button"


### PR DESCRIPTION
For the MI yamls, I was only able to successfully post messages using Chrome. I know it's not ideal but nothing else seems to work 😞. 

Also, for the success criteria of the MI yamls, the thank you message appears at the bottom of the form after the submit button is clicked, 
[![Screenshot from Gyazo](https://gyazo.com/ceb118b69b054f83da8de1820a8b1c80/raw)](https://gyazo.com/ceb118b69b054f83da8de1820a8b1c80)

I'm targeting that first "Thank you!" string as it's has a class value associated with it 
[![Screenshot from Gyazo](https://gyazo.com/49cfe1e172f678039935740fc4e1996e/raw)](https://gyazo.com/49cfe1e172f678039935740fc4e1996e)
 