### PR TITLE
Replacing word that triggers "Security Risk" alert

### DIFF
--- a/members/B001261.yaml
+++ b/members/B001261.yaml
@@ -43,6 +43,12 @@ contact_form:
           required: true
           options:
             blacklist: ":"
+    - javascript:
+        - name: Message
+          selectors: [ "#field_5722C424-8601-4ABF-A8D1-AC11B9C45F87" ]
+          values: [ "$MESSAGE" ]
+          commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
+          required: true
         - name: topic
           selector: "#field_41FAA356-B947-40CA-9264-BE321C5F5D94"
           value: $TOPIC

--- a/members/B001267.yaml
+++ b/members/B001267.yaml
@@ -55,7 +55,7 @@ contact_form:
         - name: Message
           selectors: [ "textarea#gen-fieldid-27" ]
           values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = elements[0].value.replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
           required: true
     - select:
         - name: Prefix

--- a/members/E000285.yaml
+++ b/members/E000285.yaml
@@ -51,6 +51,12 @@ contact_form:
         required: true
         options:
           blacklist: ":"
+    - javascript:
+      - name: Message
+        selectors: [ "#field_5722C424-8601-4ABF-A8D1-AC11B9C45F87" ]
+        values: [ "$MESSAGE" ]
+        commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
+        required: true
     - click_on:
       - value: Submit
         selector: form#form_D66636DE-02AE-487D-96D4-FDD63541125A div.buttonHolder input

--- a/members/G000359.yaml
+++ b/members/G000359.yaml
@@ -41,6 +41,12 @@ contact_form:
         required: true
         options:
           blacklist: ":"
+    - javascript:
+      - name: Message
+        selectors: [ "#field_5722C424-8601-4ABF-A8D1-AC11B9C45F87" ]
+        values: [ "$MESSAGE" ]
+        commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
+        required: true
     - select:
       - name: Prefix
         selector: "#field_694A4E8E-E869-4156-8A02-1D58DE8111EE"

--- a/members/M000934.yaml
+++ b/members/M000934.yaml
@@ -52,6 +52,12 @@ contact_form:
           required: true
           options:
             blacklist: ":"
+    - javascript:
+        - name: Message
+          selectors: [ "#field_5722C424-8601-4ABF-A8D1-AC11B9C45F87" ]
+          values: [ "$MESSAGE" ]
+          commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
+          required: true
     - select:
         - name: topic
           selector: select#field_D8D2B924-8B4A-44C5-B78D-FEE0F81C8D7E

--- a/members/M001111.yaml
+++ b/members/M001111.yaml
@@ -120,7 +120,7 @@ contact_form:
       - name: Message
         selectors: [ "#field_5722C424-8601-4ABF-A8D1-AC11B9C45F87" ]
         values: [ "$MESSAGE" ]
-        commands: [ "elements[0].value = elements[0].value.replace(/[\\•]/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+        commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
         required: true
     - click_on:
       - selector: form.uniForm input[type=submit]

--- a/members/P000449.yaml
+++ b/members/P000449.yaml
@@ -57,7 +57,7 @@ contact_form:
         - name: Message
           selectors: [ "textarea#field_716E154B-9C67-4EDE-97AC-A867C5556908" ]
           values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = elements[0].value.replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
           required: true
     - select:
         - name: topic

--- a/members/T000250.yaml
+++ b/members/T000250.yaml
@@ -47,6 +47,12 @@ contact_form:
         required: true
         options:
           blacklist: ":"
+    - javascript:
+        - name: Message
+          selectors: [ "#field_5722C424-8601-4ABF-A8D1-AC11B9C45F87" ]
+          values: [ "$MESSAGE" ]
+          commands: ["elements[0].value = values[0].replace(/\bset\b/ig,'determine')"]
+          required: true
     - select:
       - name: topic
         selector: select#field_6F8F9AF6-B16C-4ADD-9B4F-88F7A910C63F


### PR DESCRIPTION
Error screenies are showing up with the Security Risk alert message from the Senate when they don't like a character in the advocacy message. After lots of testing, we saw that the word "set" was the one triggering the alert. I added a JS step to these yamls that replaces that word with "determine". Did a few tests with the added JS step and msgs went thru. 

Adding @tirish as fyi as he helped me out with the js step

PS- these are all of they yamls I could find that are presenting this issue. If there are more tomorrow/later this week, I'll open another PR to handle that. 

