### PR TITLE
Add phone number step

### DIFF
--- a/members/MDL000260.yaml
+++ b/members/MDL000260.yaml
@@ -33,6 +33,10 @@ contact_form:
           selector: "#ctlContactLegislator_txtMessage"
           value: $MESSAGE
           required: true
+        - name: Phone Number
+          selector: "input#ctlContactLegislator_txtPhoneNumber"
+          value: $PHONE
+          required: true
     - javascript:
         - name: phone
           selectors: [ "input#ctlContactLegislator_txtPhoneNumber"]


### PR DESCRIPTION
Adding a normal `phone` step to require supporters to add that information when filling out the form. As of now, yamltron is ignoring the `phone` step that's in the JS step. 