### PR TITLE
hardcode country step

### DIFF
--- a/members/CusA27255d55CusA27255d55.yaml
+++ b/members/CusA27255d55CusA27255d55.yaml
@@ -13,7 +13,16 @@ contact_form:
     - wait:
         - value: 1
     - find:
-      - selector: div.GIY1LSJAQC form
+        - selector: input#x-auto-9-input
+    - fill_in:
+        - name: country
+          selector: input#x-auto-9-input
+          value: "United States"
+          required: true
+    - wait:
+        - value: 2
+    - find:
+        - selector: div.GIY1LSJAQC form
     - fill_in:
         - name: message
           selector: textarea#x-auto-0-input

--- a/members/CusAf521eaee1549052166.yaml
+++ b/members/CusAf521eaee1549052166.yaml
@@ -13,7 +13,16 @@ contact_form:
     - wait:
         - value: 1
     - find:
-      - selector: div.GIY1LSJAQC form
+        - selector: input#x-auto-9-input
+    - fill_in:
+        - name: country
+          selector: input#x-auto-9-input
+          value: "United States"
+          required: true
+    - wait:
+        - value: 2
+    - find:
+        - selector: div.GIY1LSJAQC form
     - fill_in:
         - name: message
           selector: textarea#x-auto-0-input


### PR DESCRIPTION
This is to make sure "United States" is present in the country field for these two custom targets. In the form, this input has a dropdown menu, but the country can also be typed in. I created an extra `fill_in` step for this, plus added a small wait after `fill_in` to make sure the right input was in place. 

During tests, this process looks like this 

[![Screenshot from Gyazo](https://gyazo.com/5c2734f5f6774f1d1388595b13ef4a1c/raw)](https://gyazo.com/5c2734f5f6774f1d1388595b13ef4a1c)