### PR TITLE
Minor fixes: update success message criteria; update submit button selector

### DIFF
--- a/members/FNDSe6391ff5.yaml
+++ b/members/FNDSe6391ff5.yaml
@@ -74,4 +74,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: "Thank you, your message has been sent"
+      excludes: "Message Details"

--- a/members/ILL001004.yaml
+++ b/members/ILL001004.yaml
@@ -35,7 +35,7 @@ contact_form:
         - value: unsub2
           selector: "#feedback_mobile_opt_in"
         - value: Submit
-          selector: input[type='submit'][value='Send Email']
+          selector: input[type='submit'][value='Send e-mail']
     - wait:
       - value: 10
   success:


### PR DESCRIPTION
US Sen Cramer's form has a new Thank You message. I suspect this message might be temporary, cuz it's really random [![Screenshot from Gyazo](https://gyazo.com/6a461db7957957f0db32362426775083/raw)](https://gyazo.com/6a461db7957957f0db32362426775083) Instead of changing the string to look for in the yaml, I just swapped `contains` for `excludes` to make sure the yaml doesn't break if/when they change the message back to something for thank you-y. 

For ILL001004, the submit `button` selector needed a small update 