### PR TITLE
Minor change to value to topic step

### DIFF
--- a/members/SCAG3f267647.yaml
+++ b/members/SCAG3f267647.yaml
@@ -21,7 +21,7 @@ contact_form:
     - select:
         - name: topic
           selector: "#subject"
-          value: OTHER
+          value: $TOPIC
           required: true
           options:
             Animal Issues/Concerns: Animal Issues/Concerns


### PR DESCRIPTION
I missed the `$TOPIC` value in the previous updated 

🤦‍♂️ 

Note: this topic makes the `$SUBJECT` value not as relevant as before since, once a topic is selected, the subject input does not appear in the form's step2. 

ie, when Environment is selected as topic 
[![Screenshot from Gyazo](https://gyazo.com/8a610423bdec9947e0265775a7ec61c5/raw)](https://gyazo.com/8a610423bdec9947e0265775a7ec61c5)

vs

when OTHER is selected as topic 
[![Screenshot from Gyazo](https://gyazo.com/f6e92e8b7d0fcfc695cb92f8f3b0a8ce/raw)](https://gyazo.com/f6e92e8b7d0fcfc695cb92f8f3b0a8ce)

There are several topics mapped to OTHER in Artemis, so I don't think we could get rid of `$SUBJECT` in this yaml

