### PR TITLE
Delete other prefix options

### DIFF
--- a/members/B001236.yaml
+++ b/members/B001236.yaml
@@ -63,7 +63,6 @@ contact_form:
           "Reverend": "Reverend"
           "Sister": "Sister"
           "Pastor": "Pastor"
-          "Other": "Other"
     - click_on:
       - value: Submit
         selector: input[type='submit'][value='Submit']

--- a/members/K000384.yaml
+++ b/members/K000384.yaml
@@ -99,7 +99,6 @@ contact_form:
           - Sergeant: Sergeant
           - Vice Admiral: Vice Admiral
           - Warrat Officer: Warrant Officer
-          - Other: Other
       - name: Topic
         selector: select#input-B388ADF0-5056-A066-6033-31CCE02BC3DA
         value: $TOPIC


### PR DESCRIPTION
Both Sen Kaine and Boozman require supporters to specify a Prefix if `Other` is selected as one of the options in the dropdown menu. We don't support this, so deleting this option from their yamls.