### PR TITLE
Taking click_on step out

### DIFF
--- a/members/C001056.yaml
+++ b/members/C001056.yaml
@@ -92,7 +92,6 @@ contact_form:
         value: Texas
         required: false
     - click_on:
-      - selector: "#edit-submitted-flag-acknowledgement-1"
       - selector: input[type='submit'][value='Preview']
     - wait:
       - value: 3


### PR DESCRIPTION
The flag request checkbox was taken out of the target's form. Leaving it there is causing yamltron to throw 500 errors when attempting to send the payload. Taking that selector out to make sure submissions are successfully delivered