### PR TITLE
Add find step; Move CT target back to members

### DIFF
--- a/members/C001056.yaml
+++ b/members/C001056.yaml
@@ -96,6 +96,8 @@ contact_form:
         selector: "#edit-submitted-address-administrative-area"
         value: Texas
         required: false
+    - find:
+      - value: input[type='submit'][value='Preview']
     - click_on:
       - selector: input[type='submit'][value='Preview']
     - wait:

--- a/members/CTL000273.yaml
+++ b/members/CTL000273.yaml
@@ -5,11 +5,11 @@ contact_form:
   steps:
     - visit: "http://ctsenaterepublicans.com/contact-berthel/"
     - fill_in:
-        - name: first
+        - name: First Name
           selector: input#input_118_1
           value: $NAME_FIRST
           required: true
-        - name: last
+        - name: Last Name
           selector: input#input_118_2
           value: $NAME_LAST
           required: true
@@ -21,11 +21,11 @@ contact_form:
           selector: input#input_118_4
           value: $PHONE
           required: true
-        - name: street
+        - name: Street
           selector: input#input_118_5
           value: $ADDRESS_STREET
           required: true
-        - name: street2
+        - name: Street 2
           selector: input#input_118_6
           value: $ADDRESS_STREET_2
           required: false


### PR DESCRIPTION
Adding `find` step before the `click_on` to see help with submissions

Edit: I found a CT that no longer has recaptcha and moved him back to the members folder