### PR TITLE
Add usechrome flag to yaml

### DIFF
--- a/members/CusB729dc0101592930443.yaml
+++ b/members/CusB729dc0101592930443.yaml
@@ -1,6 +1,7 @@
 bioguide: CusB729dc0101592930443
 contact_form:	
-  method: post	
+  method: post
+  usechrome: true	
   steps:	
     - visit: "https://eplanning.blm.gov/eplanning-ui/project/68107/595/8001159/comment"	
     - find: 
@@ -108,9 +109,8 @@ contact_form:
     - click_on:
       - selector: "#comment-view-page button.btn.btn-primary"
     - find:
-      - selector: "#comment-receipt-page div.mb-4 h4"
+      - selector: "#comment-receipt-page h4"
   success:	
-    headers:	
-      status: 200	
-    body:	
+    body:
+      excludes: "Processing, please wait"
       contains: "Your Submission ID"

--- a/members/CusB729dc0101592930443.yaml
+++ b/members/CusB729dc0101592930443.yaml
@@ -110,6 +110,8 @@ contact_form:
       - selector: "#comment-view-page button.btn.btn-primary"
     - find:
       - selector: "#comment-receipt-page h4"
+    - wait:
+      - value: 2
   success:	
     body:
       contains: "Your Submission ID"

--- a/members/CusB729dc0101592930443.yaml
+++ b/members/CusB729dc0101592930443.yaml
@@ -112,5 +112,4 @@ contact_form:
       - selector: "#comment-receipt-page h4"
   success:	
     body:
-      excludes: "Processing, please wait"
       contains: "Your Submission ID"


### PR DESCRIPTION
Adding `usechrome` to make sure messages are being delivered successfully to this target.

Note: as of 6/26/20, this is meant as temporary measure while we figure out how to successfully sent msgs without using chrome