### PR TITLE
Add js step to replace percentage sign in advo message

### DIFF
--- a/members/B000944.yaml
+++ b/members/B000944.yaml
@@ -50,7 +50,7 @@ contact_form:
       - name: accent-replace
         values: ["$NAME_FIRST", "$NAME_LAST"]
         selectors: ["#input-466BAE61-E646-3957-206E-507B30B9CC9C", "#input-466BB01B-E6B3-9F1C-54B0-74E30CA82B2D"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['á']/g, 'a').replace(/[èé]/g,'e').replace(/[ñ]/g, 'n').replace(/[']/g, '').replace(/['%20']/g, ''); }"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['á']/g, 'a').replace(/[èé]/g,'e').replace(/[ñ]/g, 'n').replace(/[']/g, '').replace(/(%2[0C])/g, ''); }"]
         required: true
     - select:
       - name: Your Prefix

--- a/members/B000944.yaml
+++ b/members/B000944.yaml
@@ -50,7 +50,7 @@ contact_form:
       - name: accent-replace
         values: ["$NAME_FIRST", "$NAME_LAST"]
         selectors: ["#input-466BAE61-E646-3957-206E-507B30B9CC9C", "#input-466BB01B-E6B3-9F1C-54B0-74E30CA82B2D"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['á']/g, 'a').replace(/[èé]/g,'e').replace(/[ñ]/g, 'n').replace(/[']/g, ''); }"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['á']/g, 'a').replace(/[èé]/g,'e').replace(/[ñ]/g, 'n').replace(/[']/g, '').replace(/['%20']/g, ''); }"]
         required: true
     - select:
       - name: Your Prefix
@@ -298,7 +298,5 @@ contact_form:
     - find:
       - selector: p[class='mb-4']
   success:
-    headers:
-      status: 200
     body:
       contains: "Thank you for contacting me."

--- a/members/B001230.yaml
+++ b/members/B001230.yaml
@@ -1,7 +1,6 @@
 bioguide: B001230
 contact_form:
   method: POST
-  action: ""
   steps:
     - visit: "https://www.baldwin.senate.gov/feedback"
     - find:
@@ -56,6 +55,12 @@ contact_form:
       - name: message
         selector: textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2
         value: $MESSAGE
+        required: true
+    - javascript:
+      - name: char replace
+        values: ["$MESSAGE"]
+        selectors: ["textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
         required: true
     - select:
       - name: Your Prefix
@@ -252,7 +257,5 @@ contact_form:
       - value: Send
         selector: form#B03E03FC-4040-F985-52CD-BCD7E00A8A6C div.controls input.btn
   success:
-    headers:
-      status: 200
     body:
       contains: "As your United States Senator, I have made it my top priority"

--- a/members/B001230.yaml
+++ b/members/B001230.yaml
@@ -60,7 +60,7 @@ contact_form:
       - name: char replace
         values: ["$MESSAGE"]
         selectors: ["textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
         required: true
     - select:
       - name: Your Prefix

--- a/members/B001267.yaml
+++ b/members/B001267.yaml
@@ -52,7 +52,7 @@ contact_form:
         - name: Message
           selectors: [ "#field_0F40B55B-8631-4AA2-8223-08DE119CD370" ]
           values: [ "$MESSAGE" ]
-          commands: ["elements[0].value = values[0].replace(/\\b(set forth in the bill)\\b/ig,'').replace(/\\b(is not)\\b/ig,'isn\\'t').replace(/['%20']/g, '');"]
+          commands: ["elements[0].value = values[0].replace(/\\b(set forth in the bill)\\b/ig,'').replace(/\\b(is not)\\b/ig,'isn\\'t').replace(/(%2[0C])/g, '');"]
           required: true
     - select:
         - name: Your Prefix

--- a/members/B001267.yaml
+++ b/members/B001267.yaml
@@ -1,7 +1,6 @@
 bioguide: B001267
 contact_form:
   method: post
-  action: ""
   steps:
     - visit: "https://www.bennet.senate.gov/public/index.cfm/write-to-michael"
     - find:
@@ -53,7 +52,7 @@ contact_form:
         - name: Message
           selectors: [ "#field_0F40B55B-8631-4AA2-8223-08DE119CD370" ]
           values: [ "$MESSAGE" ]
-          commands: ["elements[0].value = values[0].replace(/\\b(set forth in the bill)\\b/ig,'').replace(/\\b(is not)\\b/ig,'isn\\'t')"]
+          commands: ["elements[0].value = values[0].replace(/\\b(set forth in the bill)\\b/ig,'').replace(/\\b(is not)\\b/ig,'isn\\'t').replace(/['%20']/g, '');"]
           required: true
     - select:
         - name: Your Prefix
@@ -139,7 +138,5 @@ contact_form:
     - wait:
         - value: 3
   success:
-    headers:
-      status: 200
     body:
       contains: Thank you for contacting my office to express

--- a/members/B001277.yaml
+++ b/members/B001277.yaml
@@ -93,7 +93,7 @@ contact_form:
         - name: char replace
           values: ["$MESSAGE"]
           selectors: ["textarea#comments"]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - select:
       - name: Your Prefix

--- a/members/B001277.yaml
+++ b/members/B001277.yaml
@@ -1,7 +1,6 @@
 bioguide: B001277
 contact_form:
   method: POST
-  action: ""
   steps:
     - visit: "https://www.blumenthal.senate.gov/contact/"
     - find:
@@ -48,26 +47,26 @@ contact_form:
     - find:
       - selector: div#continue-form input#fname
     - fill_in:
-      - name: fname
+      - name: First Name
         selector: "#fname"
         value: "$NAME_FIRST"
         required: true
-      - name: lname
+      - name: Last Name
         selector: "#lname"
         value: "$NAME_LAST"
         required: true
-      - name: mailing_streetAddress1
+      - name: Street Address
         selector: "#mailing_streetAddress1"
         value: "$ADDRESS_STREET"
         required: true
-      - name: mailing_streetAddress2
+      - name: Street Address2
         selector: "#mailing_streetAddress2"
         value: "$ADDRESS_STREET_2"
-      - name: mailing_city
+      - name: City
         selector: "#mailing_city"
         value: "$ADDRESS_CITY"
         required: true
-      - name: mailing_zipCode
+      - name: ZipCode
         selector: "#mailing_zipCode"
         value: "$ADDRESS_ZIP5"
         required: true
@@ -90,6 +89,12 @@ contact_form:
         selector: textarea#comments
         value: $MESSAGE
         required: true
+    - javascript:
+        - name: char replace
+          values: ["$MESSAGE"]
+          selectors: ["textarea#comments"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          required: true
     - select:
       - name: Your Prefix
         selector: "#salutation"

--- a/members/D000563.yaml
+++ b/members/D000563.yaml
@@ -1,7 +1,6 @@
 bioguide: D000563
 contact_form:
   method: post
-  action: /contact/email
   steps:
     - visit: "http://www.durbin.senate.gov/contact/email"
     - select:
@@ -53,27 +52,27 @@ contact_form:
     - find:
         - selector: "#fname"
     - fill_in:
-        - name: fname
+        - name: First Name
           selector: "#fname"
           value: $NAME_FIRST
           required: true
-        - name: lname
+        - name: Last Name
           selector: "#lname"
           value: $NAME_LAST
           required: true
-        - name: mailing_streetAddress1
+        - name: Street Address1
           selector: "#mailing_streetAddress1"
           value: $ADDRESS_STREET
           required: true
-        - name: mailing_streetAddress2
+        - name: StreetAddress2
           selector: "#mailing_streetAddress2"
           value: $ADDRESS_STREET_2
           required: false
-        - name: mailing_city
+        - name: City
           selector: "#mailing_city"
           value: $ADDRESS_CITY
           required: true
-        - name: mailing_zipCode
+        - name: ZipCode
           selector: "#mailing_zipCode"
           value: $ADDRESS_ZIP5
           required: true
@@ -81,7 +80,7 @@ contact_form:
           selector: "#home_phone_number"
           value: $PHONE
           required: true
-        - name: email_address
+        - name: email
           selector: "#email"
           value: $EMAIL
           required: true
@@ -97,13 +96,11 @@ contact_form:
           selector: textarea#message
           value: $MESSAGE
           required: true
-          options:
-            blacklist: ":"
     - javascript:
         - name: Message
-          selectors: [ "#message" ]
+          selectors: [ "textarea#message" ]
           values: [ "$MESSAGE" ]
-          commands: [ "elements[0].value = elements[0].value.replace(/[\\%]/gi, ' ').replace(/www\\.youtube\\.com\\/watch?[^&]*(&)?v=/gi, 'youtu.be/')" ]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - select:
         - name: Your Prefix
@@ -254,7 +251,5 @@ contact_form:
         - value: Thank you
           selector: "p"
   success:
-    headers:
-      status: 200
     body:
       contains: Thank you

--- a/members/D000622.yaml
+++ b/members/D000622.yaml
@@ -132,7 +132,7 @@ contact_form:
         - name: char replace
           values: ["$MESSAGE"]
           selectors: ["textarea#input-356E5E00-5056-A066-603C-9FAC0F3B6888"]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - click_on:
         - selector: input[type='submit'][value='Submit']

--- a/members/D000622.yaml
+++ b/members/D000622.yaml
@@ -128,12 +128,16 @@ contact_form:
           selector: textarea#input-356E5E00-5056-A066-603C-9FAC0F3B6888
           value: $MESSAGE
           required: true
+    - javascript:
+        - name: char replace
+          values: ["$MESSAGE"]
+          selectors: ["textarea#input-356E5E00-5056-A066-603C-9FAC0F3B6888"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          required: true
     - click_on:
         - selector: input[type='submit'][value='Submit']
     - wait:
         - value: 3
   success:
-    headers:
-      status: 200
     body:
       contains: "Thank you for contacting my office"

--- a/members/F000062.yaml
+++ b/members/F000062.yaml
@@ -1,7 +1,6 @@
 bioguide: F000062
 contact_form:
   method: POST
-  action: ""
   steps:
     - visit: "https://www.feinstein.senate.gov/public/index.cfm/e-mail-me"
     - wait:
@@ -40,6 +39,12 @@ contact_form:
         - name: message
           selector: textarea#field_130638F0-2EEC-4C6B-83BE-11E83BB5CED3
           value: $MESSAGE
+          required: true
+    - javascript:
+        - name: Message
+          selectors: [ "textarea#field_130638F0-2EEC-4C6B-83BE-11E83BB5CED3" ]
+          values: [ "$MESSAGE" ]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
           required: true
     - picker:
         - name: topic
@@ -104,7 +109,5 @@ contact_form:
     - wait:
         - value: 4
   success:
-    headers:
-      status: 200
     body:
       contains: "Thank you for your message"

--- a/members/F000062.yaml
+++ b/members/F000062.yaml
@@ -44,7 +44,7 @@ contact_form:
         - name: Message
           selectors: [ "textarea#field_130638F0-2EEC-4C6B-83BE-11E83BB5CED3" ]
           values: [ "$MESSAGE" ]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - picker:
         - name: topic

--- a/members/FMNS420b9c88.yaml
+++ b/members/FMNS420b9c88.yaml
@@ -48,7 +48,7 @@ contact_form:
       - name: char replace
         values: ["$MESSAGE"]
         selectors: ["div textarea[name='message']"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
         required: true
     - select:
       - name: Your Prefix

--- a/members/FMNS420b9c88.yaml
+++ b/members/FMNS420b9c88.yaml
@@ -44,6 +44,12 @@ contact_form:
         selector: div textarea[name='message']
         value: "$MESSAGE"
         required: true
+    - javascript:
+      - name: char replace
+        values: ["$MESSAGE"]
+        selectors: ["div textarea[name='message']"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        required: true
     - select:
       - name: Your Prefix
         selector: div select[name='prefix']

--- a/members/G000562.yaml
+++ b/members/G000562.yaml
@@ -1,7 +1,6 @@
 bioguide: G000562
 contact_form:
   method: post
-  action: http://www.gardner.senate.gov/contact-cory/email-cory
   steps:
     - visit: "http://www.gardner.senate.gov/contact-cory/email-cory"
     - wait:
@@ -59,6 +58,12 @@ contact_form:
         - name: message
           selector: textarea#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51
           value: $MESSAGE
+          required: true
+    - javascript:
+        - name: char replace
+          values: ["$MESSAGE"]
+          selectors: ["textarea#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
           required: true
     - select:
         - name: Your Prefix
@@ -268,7 +273,5 @@ contact_form:
     - wait:
         - value: 4
   success:
-    headers:
-      status: 200
     body:
       contains: "Thank you for submitting your comment"

--- a/members/G000562.yaml
+++ b/members/G000562.yaml
@@ -63,7 +63,7 @@ contact_form:
         - name: char replace
           values: ["$MESSAGE"]
           selectors: ["textarea#input-ADE64E73-4040-F985-52CD-A3AB6BCD2C51"]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - select:
         - name: Your Prefix

--- a/members/H001042.yaml
+++ b/members/H001042.yaml
@@ -3,7 +3,7 @@ contact_form:
   method: POST
   action: ""
   steps:
-    - visit: "https://www.hirono.senate.gov/contact"
+    - visit: "https://www.hirono.senate.gov/share-your-opinion"
     - fill_in:
       - name: firstname
         selector: input#input-B03E05C4-4040-F985-52CD-9CA44623DE5E
@@ -48,6 +48,12 @@ contact_form:
       - name: message
         selector: textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2
         value: $MESSAGE
+        required: true
+    - javascript:
+      - name: char replace
+        values: ["$MESSAGE"]
+        selectors: ["textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
         required: true
     - select:
       - name: Your Prefix

--- a/members/H001042.yaml
+++ b/members/H001042.yaml
@@ -53,7 +53,7 @@ contact_form:
       - name: char replace
         values: ["$MESSAGE"]
         selectors: ["textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
         required: true
     - select:
       - name: Your Prefix

--- a/members/K000367.yaml
+++ b/members/K000367.yaml
@@ -50,7 +50,7 @@ contact_form:
         - name: char replace
           values: ["$MESSAGE"]
           selectors: ["textarea#field_1A032E33-7721-4CE2-AD9B-2ECAFE076D8C"]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - select:
         - name: Your Prefix

--- a/members/K000367.yaml
+++ b/members/K000367.yaml
@@ -1,7 +1,6 @@
 bioguide: K000367
 contact_form:
   method: post
-  action: ""
   steps:
     - visit: "https://www.klobuchar.senate.gov/public/email-amy"
     - find:
@@ -46,6 +45,12 @@ contact_form:
         - name: Message
           selector: textarea#field_1A032E33-7721-4CE2-AD9B-2ECAFE076D8C
           value: $MESSAGE
+          required: true
+    - javascript:
+        - name: char replace
+          values: ["$MESSAGE"]
+          selectors: ["textarea#field_1A032E33-7721-4CE2-AD9B-2ECAFE076D8C"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
           required: true
     - select:
         - name: Your Prefix
@@ -118,7 +123,5 @@ contact_form:
     - wait:
         - value: 2
   success:
-    headers:
-      status: 200
     body:
       contains: "Thank you"

--- a/members/K000384.yaml
+++ b/members/K000384.yaml
@@ -1,7 +1,6 @@
 bioguide: K000384
 contact_form:
   method: POST
-  action: ""
   steps:
     - visit: "https://www.kaine.senate.gov/contact/share-your-opinion"
     - find:
@@ -46,6 +45,12 @@ contact_form:
       - name: Message
         selector: textarea#input-B388B084-5056-A066-6090-BF0C2E9BE07B
         value: $MESSAGE
+        required: true
+    - javascript:
+      - name: char replace
+        values: ["$MESSAGE"]
+        selectors: ["textarea#input-B388B084-5056-A066-6090-BF0C2E9BE07B"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
         required: true
     - select:
       - name: Your Prefix
@@ -160,7 +165,5 @@ contact_form:
       - selector: "h1"
         value: "Thank You"
   success:
-    headers:
-      status: 200
     body:
       contains: "Thanks for taking the time to share your thoughts with me"

--- a/members/K000384.yaml
+++ b/members/K000384.yaml
@@ -50,7 +50,7 @@ contact_form:
       - name: char replace
         values: ["$MESSAGE"]
         selectors: ["textarea#input-B388B084-5056-A066-6090-BF0C2E9BE07B"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
         required: true
     - select:
       - name: Your Prefix

--- a/members/M000639.yaml
+++ b/members/M000639.yaml
@@ -94,6 +94,12 @@ contact_form:
           selector: textarea#message
           value: $MESSAGE
           required: true
+    - javascript:
+        - name: char replace
+          values: ["$MESSAGE"]
+          selectors: ["textarea#message"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          required: true
     - select:
         - name: Your Prefix
           selector: "#salutation"

--- a/members/M000639.yaml
+++ b/members/M000639.yaml
@@ -98,7 +98,7 @@ contact_form:
         - name: char replace
           values: ["$MESSAGE"]
           selectors: ["textarea#message"]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - select:
         - name: Your Prefix

--- a/members/M001169.yaml
+++ b/members/M001169.yaml
@@ -108,7 +108,7 @@ contact_form:
         - name: char replace
           values: ["$MESSAGE"]
           selectors: ["textarea#message"]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - select:
         - name: Your Prefix

--- a/members/M001169.yaml
+++ b/members/M001169.yaml
@@ -1,7 +1,6 @@
 bioguide: M001169
 contact_form:
   method: post
-  action: /contact
   steps:
     - visit: "http://www.murphy.senate.gov/contact"
     - select:
@@ -105,6 +104,12 @@ contact_form:
           selector: textarea#message
           value: $MESSAGE
           required: true
+    - javascript:
+        - name: char replace
+          values: ["$MESSAGE"]
+          selectors: ["textarea#message"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          required: true
     - select:
         - name: Your Prefix
           selector: select#salutation
@@ -131,7 +136,5 @@ contact_form:
         - selector: "h2"
           value: "THANK YOU"
   success:
-    headers:
-      status: 200
     body:
       contains: Thanks for taking the time to share your thoughts with me.

--- a/members/M001176.yaml
+++ b/members/M001176.yaml
@@ -1,7 +1,6 @@
 bioguide: M001176
 contact_form:
   method: post
-  action: ""
   steps:
     - visit: "http://www.merkley.senate.gov/contact/"
     - select:
@@ -18,27 +17,27 @@ contact_form:
     - find:
         - selector: "#fname"
     - fill_in:
-        - name: fname
+        - name: First Name
           selector: "#fname"
           value: $NAME_FIRST
           required: true
-        - name: lname
+        - name: Last Name
           selector: "#lname"
           value: $NAME_LAST
           required: true
-        - name: mailing_streetAddress1
+        - name: Street Address
           selector: "#mailing_streetAddress1"
           value: $ADDRESS_STREET
           required: true
-        - name: mailing_streetAddress2
+        - name: Street Address2
           selector: "#mailing_streetAddress2"
           value: $ADDRESS_STREET_2
           required: false
-        - name: mailing_city
+        - name: city
           selector: "#mailing_city"
           value: $ADDRESS_CITY
           required: true
-        - name: mailing_zipCode
+        - name: zipCode
           selector: "#mailing_zipCode"
           value: $ADDRESS_ZIP5
           required: true
@@ -57,6 +56,12 @@ contact_form:
         - name: message
           selector: textarea#message
           value: $MESSAGE
+          required: true
+    - javascript:
+        - name: char replace
+          values: ["$MESSAGE"]
+          selectors: ["textarea#message"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
           required: true
     - select:
         - name: subject

--- a/members/M001176.yaml
+++ b/members/M001176.yaml
@@ -61,7 +61,7 @@ contact_form:
         - name: char replace
           values: ["$MESSAGE"]
           selectors: ["textarea#message"]
-          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+          commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
           required: true
     - select:
         - name: subject

--- a/members/S000770.yaml
+++ b/members/S000770.yaml
@@ -1,7 +1,6 @@
 bioguide: S000770
 contact_form:
   method: POST
-  action: ""
   steps:
     - visit: "https://www.stabenow.senate.gov/contact"
     - wait:
@@ -9,11 +8,11 @@ contact_form:
     - find:
       - selector: "#input-F80AC606-4040-F985-52CD-88C5E17C2923"
     - fill_in:
-      - name: firstName
+      - name: First Name
         selector: "#input-F80AC606-4040-F985-52CD-88C5E17C2923"
         value: $NAME_FIRST
         required: true
-      - name: lastName
+      - name: Last Name
         selector: "#input-F80AC4BA-4040-F985-52CD-C1FBF3A239DA"
         value: $NAME_LAST
         required: true
@@ -53,6 +52,12 @@ contact_form:
         selector: textarea#input-F80AC5B6-4040-F985-52CD-834C1DD62DF3
         value: $MESSAGE
         required: true
+    - javascript:
+      - name: char replace
+        values: ["$MESSAGE"]
+        selectors: ["textarea#input-F80AC5B6-4040-F985-52CD-834C1DD62DF3"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        required: true
     - click_on:
       - value: Submit
         selector: input[value='Submit']
@@ -60,7 +65,5 @@ contact_form:
       - selector: "p"
         value: "Thank you!"
   success:
-    headers:
-      status: 200
     body:
       contains: "Thank you for contacting my office!"

--- a/members/S000770.yaml
+++ b/members/S000770.yaml
@@ -56,7 +56,7 @@ contact_form:
       - name: char replace
         values: ["$MESSAGE"]
         selectors: ["textarea#input-F80AC5B6-4040-F985-52CD-834C1DD62DF3"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
         required: true
     - click_on:
       - value: Submit

--- a/members/T000476.yaml
+++ b/members/T000476.yaml
@@ -44,7 +44,7 @@ contact_form:
       - name: char replace
         values: ["$MESSAGE"]
         selectors: ["textarea#field_279EFB03-F78D-4924-8599-F04AEB99A7A6"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/(%2[0C])/g, '');}"]
         required: true
     - select:
       - name: Your Prefix

--- a/members/T000476.yaml
+++ b/members/T000476.yaml
@@ -1,45 +1,50 @@
 bioguide: T000476
 contact_form:
   method: post
-  action:
   steps:
     - visit: "https://www.tillis.senate.gov/email-me"
     - fill_in:
-      - name: "first_name"
+      - name: First Name
         selector: "#field_554EB441-1332-47D8-B817-87A030531FCC"
         value: $NAME_FIRST
         required: true
-      - name: "last_name"
+      - name: Last Name
         selector: "#field_77689247-ECBE-4E25-97D6-62F8A979E226"
         value: $NAME_LAST
         required: true
-      - name: "address"
+      - name: Address
         selector: "#field_47F809FC-8DE7-4768-95BE-6B94DCC7C8C8"
         value: $ADDRESS_STREET
         required: true
-      - name: "city"
+      - name: City
         selector: "#field_965E8165-21F8-49A4-AAD0-E72A361EC2DB"
         value: $ADDRESS_CITY
         required: true
-      - name: "zip"
+      - name: Zip
         selector: "#field_F35EA2FD-C92A-4FFC-9CE0-637B8AEECB54"
         value: $ADDRESS_ZIP5
         required: true
-      - name: "phone"
+      - name: Phone
         selector: "#field_64322B9D-7F15-47DA-B656-9843D7D04866"
         value: $PHONE_HYPHENS
         required: true
-      - name: "email"
+      - name: Email
         selector: "#field_5C0C729A-D702-46F1-9821-7DD7E565E136"
         value: $EMAIL
         required: true
-      - name: "subject"
+      - name: Subject
         selector: "#field_E2D2548D-F3B7-48F7-9BD0-E29F4ED82A43"
         value: $SUBJECT
         required: true
       - name: message
         selector: textarea#field_279EFB03-F78D-4924-8599-F04AEB99A7A6
         value: $MESSAGE
+        required: true
+    - javascript:
+      - name: char replace
+        values: ["$MESSAGE"]
+        selectors: ["textarea#field_279EFB03-F78D-4924-8599-F04AEB99A7A6"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]
         required: true
     - select:
       - name: Your Prefix
@@ -228,7 +233,5 @@ contact_form:
     - wait:
       - value: 10
   success:
-    headers:
-      status: 200
     body:
       contains: "Someone from my office will be in touch"


### PR DESCRIPTION
Adding this js step:
`commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['%20']/g, '');}"]`

to several affected US Senators' yamls to find a replace the percentage sign that is triggering the security risk alert. These are all the yaml that I saw were presenting this issue, but there could be a few that I may have missed, fyi. 

In addition to the above, I'm doing a few other minor changes to the yamls such as removing the `action` and `success` steps (those are not really needed in the yamls), and updating other step names that are supporter facing (ie, First Name, Last Name, etc).