### PR TITLE
update yalm steps; add additional js step

### DIFF
--- a/members/B000944.yaml
+++ b/members/B000944.yaml
@@ -52,6 +52,11 @@ contact_form:
         selectors: ["#input-466BAE61-E646-3957-206E-507B30B9CC9C", "#input-466BB01B-E6B3-9F1C-54B0-74E30CA82B2D", "#input-46FB1CCB-BE54-C379-D785-A4F0D5700E52"]
         commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = values[i].replace(/['á']/g, 'a').replace(/[èé]/g,'e').replace(/[ñ]/g, 'n').replace(/[']/g, '').replace(/(%2[0C])/g, ''); }"]
         required: true
+      - name: leading-1-phone-replace
+        values: ["$PHONE"]
+        selectors: ["#input-466BAEC8-071D-301C-5A55-C90E1AB5F66C"]
+        commands: [ "elements[0].value = values[0].replace(/\D/g,'').length > 10 ? values[0].replace(/\D/g,'').substr(1) : values[0].replace(/\D/g,'')" ]
+        required: true
     - select:
       - name: Your Prefix
         selector: "#input-466BAFA0-D277-8380-464E-5B0ED2A514DE"

--- a/members/state_ma_gov_charlie_baker.yaml
+++ b/members/state_ma_gov_charlie_baker.yaml
@@ -3,6 +3,15 @@ contact_form:
   method: post
   steps:
     - visit: "https://www.mass.gov/forms/email-the-governors-office"
+    - select:
+      - name: Comment select
+        selector: "#field90831234"
+        value: Comment
+        required: true  
+      - name: Topic
+        selector: "#field90831245"
+        value: Other
+        required: true     
     - fill_in:
         - name: First Name
           selector: input#field49751862
@@ -45,14 +54,9 @@ contact_form:
           value: $SUBJECT
           required: true
         - name: message
-          selector: textarea#field49752026
+          selector: div textarea.fsRequired
           value: $MESSAGE
           required: true
-    - select:
-      - name: Topic
-        selector: "#field90831245"
-        value: Other
-        required: true     
     - click_on:
         - value: Submit
           selector: input#fsSubmitButton1744869


### PR DESCRIPTION
For state_ma_gov_charlie_baker, I think the order of `fill-in` then `select` steps was causing yamltron not to successfully find the `message` textarea. Flipped these steps, and added a missing `select`, and it works. 