### PR TITLE
Update success message; create custom target

### DIFF
--- a/members/CusSbe18f11a1605817331.yaml
+++ b/members/CusSbe18f11a1605817331.yaml
@@ -1,0 +1,133 @@
+bioguide: CusSbe18f11a1605817331
+contact_form:	
+  method: post
+  usechrome: true	
+  steps:	
+    - visit: "https://eplanning.blm.gov/eplanning-ui/project/2002801/595/8001834/comment"	
+    - find: 
+      - selector: "#comment"
+    - fill_in: 
+      - name: Message 
+        selector: "#comment"
+        value: $MESSAGE
+        required: true 
+      - name: First Name
+        selector: "#first-name"	
+        value: $NAME_FIRST	
+        required: false	
+      - name: Last Name	
+        selector: "#last-name"	
+        value: $NAME_LAST	
+        required: false	
+    - find: 
+      - selector: "#additional-info"
+    - click_on: 
+      - selector: "#additional-info"
+    - find: 
+      - selector: "#line1"
+    - fill_in:
+      - name: Street Address
+        selector: "#line1" 
+        value: $ADDRESS_STREET  
+        required: false
+      - name: Street Address
+        selector: "#line2" 
+        value: $ADDRESS_STREET_2  
+        required: false
+      - name: City
+        selector: "#city" 
+        value: $ADDRESS_CITY
+        required: false
+      - name: zip
+        selector: "#zip" 
+        value: $ADDRESS_ZIP5  
+        required: false
+      - name: email
+        selector: "#email" 
+        value: $EMAIL 
+        required: false
+      - name: phone
+        selector: "#phone" 
+        value: $PHONE
+        required: false
+    - select:
+      - name: State
+        selector: "#state" 
+        value: $ADDRESS_STATE_FULL  
+        required: false
+        options:
+          Alaska: Alaska
+          Alabama: Alabama
+          American Samoa: American Samoa
+          Arizona: Arizona
+          Arkansas: Arkansas
+          California: California
+          Colorado: Colorado
+          Connecticut: Connecticut
+          Delaware: Delaware
+          District of Columbia: District of Columbia
+          Florida: Florida
+          Georgia: Georgia
+          Guam: Guam
+          Hawaii: Hawaii
+          Idaho: Idaho
+          Illinois: Illinois
+          Indiana: Indiana
+          Iowa: Iowa
+          Kansas: Kansas
+          Kentucky: Kentucky
+          Louisiana: Louisiana
+          Maine: Maine
+          Maryland: Maryland
+          Massachusetts: Massachusetts
+          Michigan: Michigan
+          Minnesota: Minnesota
+          Mississippi: Mississippi
+          Missouri: Missouri
+          Montana: Montana
+          Nebraska: Nebraska
+          Nevada: Nevada
+          New Hampshire: New Hampshire
+          New Jersey: New Jersey
+          New Mexico: New Mexico
+          New York: New York
+          North Carolina: North Carolina
+          North Dakota: North Dakota
+          Northern Mariana Islands: Northern Mariana Islands
+          Ohio: Ohio
+          Oklahoma: Oklahoma
+          Oregon: Oregon
+          Pennsylvania: Pennsylvania
+          Puerto Rico: Puerto Rico
+          Rhode Island: Rhode Island
+          South Carolina: South Carolina
+          South Dakota: South Dakota
+          Tennessee: Tennessee
+          Texas: Texas
+          U.S. Virgin Islands: U.S. Virgin Islands
+          Utah: Utah
+          Virginia: Virginia
+          Vermont: Vermont
+          Washington: Washington
+          West Virginia: West Virginia
+          Wisconsin: Wisconsin
+          Wyoming: Wyoming             
+    - find:
+      - selector: "div.standard-btns button.btn.btn-primary"
+    - click_on:	
+      - selector: "div.standard-btns button.btn.btn-primary"
+    - find:
+      - selector: "#withhold-pii-yes"
+    - click_on:
+      - selector: "#withhold-pii-yes"
+    - find:
+      - selector: "#comment-view-page button.btn.btn-primary"
+    - click_on:
+      - selector: "#comment-view-page button.btn.btn-primary"
+    - find:
+      - selector: "#comment-receipt-page h4"
+    - wait:
+      - value: 2
+  success:	
+    body:
+      contains: "Your Submission ID"

--- a/members/SPAL44fc649b.yaml
+++ b/members/SPAL44fc649b.yaml
@@ -50,4 +50,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: your message has been received
+      contains: Thank you for contacting the office


### PR DESCRIPTION
Custom target related to VAN-90758

- As mentioned, I had to add the `usechrome` flag to the yaml to make sure successions were successful. We throttle configs we have in place for this domain should help. In any case, I'll keep a close eye on this target