### PR TITLE
Update driver steps

### DIFF
--- a/members/B001288.yaml
+++ b/members/B001288.yaml
@@ -2,7 +2,6 @@
 bioguide: B001288
 contact_form:
   method: post
-  usephantomjslogging: true
   driver: phantom
   steps:
     - visit: "https://www.booker.senate.gov/contact/write-to-cory/form"

--- a/members/D000622.yaml
+++ b/members/D000622.yaml
@@ -2,8 +2,6 @@
 bioguide: D000622
 contact_form:
   method: post
-  usephantomjslogging: true
-  driver: phantom
   steps:
     - visit: "https://www.duckworth.senate.gov/connect/email-tammy"
     - find:

--- a/members/D000622.yaml
+++ b/members/D000622.yaml
@@ -2,6 +2,7 @@
 bioguide: D000622
 contact_form:
   method: post
+  driver: phantom
   steps:
     - visit: "https://www.duckworth.senate.gov/connect/email-tammy"
     - find:

--- a/members/K000383.yaml
+++ b/members/K000383.yaml
@@ -2,6 +2,7 @@
 bioguide: K000383
 contact_form:
   method: post
+  driver: phantom
   steps:
     - visit: "http://www.king.senate.gov/contact"
     - find:

--- a/members/K000383.yaml
+++ b/members/K000383.yaml
@@ -2,8 +2,6 @@
 bioguide: K000383
 contact_form:
   method: post
-  usephantomjslogging: true
-  driver: phantom
   steps:
     - visit: "http://www.king.senate.gov/contact"
     - find:

--- a/members/SMEA392_399491.yaml
+++ b/members/SMEA392_399491.yaml
@@ -1,6 +1,7 @@
 bioguide: SMEA392_399491
 contact_form:
   method: post
+  driver: chrome
   steps:
     - visit: "https://www.maine.gov/ag/contact.html"
     - fill_in:

--- a/members/SMEA392_399491.yaml
+++ b/members/SMEA392_399491.yaml
@@ -1,8 +1,6 @@
 bioguide: SMEA392_399491
 contact_form:
   method: post
-  usechrome: true
-  driver: chrome
   steps:
     - visit: "https://www.maine.gov/ag/contact.html"
     - fill_in:

--- a/members/federal_us_firstlady_jill_biden.yaml
+++ b/members/federal_us_firstlady_jill_biden.yaml
@@ -1,7 +1,6 @@
 bioguide: federal_us_firstlady_jill_biden
 contact_form:
   method: post
-  usephantomjslogging: true
   driver: phantom
   steps:
     - visit: "https://www.whitehouse.gov/contact/"

--- a/members/federal_us_president_joe_biden.yaml
+++ b/members/federal_us_president_joe_biden.yaml
@@ -1,7 +1,6 @@
 bioguide: federal_us_president_joe_biden
 contact_form:
   method: post
-  usephantomjslogging: true
   driver: phantom
   steps:
     - visit: "https://www.whitehouse.gov/contact/"

--- a/members/federal_us_vicepresident_kamala_harris.yaml
+++ b/members/federal_us_vicepresident_kamala_harris.yaml
@@ -1,7 +1,6 @@
 bioguide: federal_us_vicepresident_kamala_harris
 contact_form:
   method: post
-  usephantomjslogging: true
   driver: phantom
   steps:
     - visit: "https://www.whitehouse.gov/contact/"

--- a/members/state_wa_gov_jay_inslee.yaml
+++ b/members/state_wa_gov_jay_inslee.yaml
@@ -1,6 +1,7 @@
 bioguide: state_wa_gov_jay_inslee
 contact_form:
   method: post
+  driver: phantom
   steps:
     - visit: "https://iqconnect.lmhostediq.com/iqextranet/EForm.aspx?__cid=FSL_WA_GOV&__fid=100021"
     - find:

--- a/members/state_wa_gov_jay_inslee.yaml
+++ b/members/state_wa_gov_jay_inslee.yaml
@@ -1,8 +1,6 @@
 bioguide: state_wa_gov_jay_inslee
 contact_form:
   method: post
-  usephantomjslogging: true
-  driver: phantom
   steps:
     - visit: "https://iqconnect.lmhostediq.com/iqextranet/EForm.aspx?__cid=FSL_WA_GOV&__fid=100021"
     - find:


### PR DESCRIPTION
`usephantomjs`

- I tested and confirmed that the  `usephantomjslogging: true` flag can be removed in 4 of the 7 yamls. Submissions were successful w/o the `phatom` flag
- Note: there *is* a browser alert that pops up when trying to submit msgs to `state_wa_gov_jay_inslee`'s contact form ([screenshot](https://gyazo.com/aa4fde2e66b1ae1a501398be61522476)). Nonetheless, the yaml has a step in place to deal with that browser alert. I confirmed that messages succeed w/o having `phantom` explicitly in the yaml, but wanted to flag just in case

`usechrome`

- I tested the yaml and confirmed that the `usechrome: true` flag can be removed. Submissions were successful w/o the `chrome` flag