### PR TITLE
Adding js replace of chars

### DIFF
--- a/members/C001056.yaml
+++ b/members/C001056.yaml
@@ -40,7 +40,7 @@ contact_form:
     - javascript:
       - name: char replace
         selectors: ["#edit-submitted-write-a-brief-message"]
-        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = elements[i].value.replace(/[(]/g,'[').replace(/[)]/g,']');}"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = elements[i].value.replace(/[(]/g,'[').replace(/[)]/g,']').replace(/(%2[0C])/g, '');}"]
         required: true
     - select:
       - name: Topic

--- a/members/M001183.yaml
+++ b/members/M001183.yaml
@@ -55,6 +55,11 @@ contact_form:
         selector: textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2
         value: $MESSAGE
         required: true
+    - javascript:
+      - name: char replace
+        selectors: ["textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2"]
+        commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = elements[i].value.replace(/(%2[0C])/g, '');}"]
+        required: true
     - select:
       - name: Your Prefix
         selector: select#input-B03E0527-4040-F985-52CD-C0DD6BEF325F


### PR DESCRIPTION
Adding js step to replace the `%20` char in a client's advo message that's affecting msg submissions. 

We had this `replace` for Cornyn (C001056), so putting it back in. We didn't have it for Manchin (M001183). Confirmed that, currently, this is only affecting these two targets. 