### PR TITLE
create custom target yaml; sneak in another edit to Scott's yaml

### DIFF
--- a/members/CusC19d978341628264253.yaml
+++ b/members/CusC19d978341628264253.yaml
@@ -1,0 +1,41 @@
+bioguide: CusC19d978341628264253
+contact_form:	
+  driver: simple	
+  steps:	
+    - visit: "https://ngpvan-freedom-tools.herokuapp.com/regulationsGov"	
+    - find:	
+        - selector: input#document_id	
+    - fill_in:	
+        - name: Document Id	
+          selector: "#document_id"	
+          value: "ED-2021-OUS-0082-0001" # regsgov document id
+          required: true	
+        - name: Comment	
+          selector: "#comment"	
+          value: $MESSAGE	
+          required: true	
+        - name: First Name	
+          selector: "#firstname"	
+          value: $NAME_FIRST	
+          required: true	
+        - name: Last Name	
+          selector: "#lastname"	
+          value: $NAME_LAST	
+          required: true	
+        - name: City	
+          selector: "#city"	
+          value: $ADDRESS_CITY	
+          required: false	
+        - name: State	
+          selector: "#stateprovince"	
+          value: $ADDRESS_STATE_POSTAL_ABBREV	
+          required: false	
+        - name: zip5	
+          selector: "#zip"	
+          value: $ADDRESS_ZIP5	
+          required: false	
+    - click_on:	
+        - selector: "#submit_btn"	
+  success:	
+    body:	
+      contains: "Success!"

--- a/members/FFLS49cdc10a.yaml
+++ b/members/FFLS49cdc10a.yaml
@@ -104,7 +104,7 @@ contact_form:
         value: $MESSAGE
         required: true
         options:
-          max_length: 500
+          max_length: 480
     - javascript:
       - name: char replace
         values: ["$MESSAGE"]


### PR DESCRIPTION
- Custom target yaml points to this form: https://www.regulations.gov/commenton/ED-2021-OUS-0082-0001
- RE Rick Scott: the `max_length` number I originally added didn't account for spaces or new lines. Tested and saw that messages were still failing even after truncation due to those spaces/lines. Took a cue from what we did for Gov Kemp (`SGAG36eb0dbc`) and lowered `max_length` to 480. Tested with a couple payloads from client messages are got Successes

PS- hopefully this will be the last edit to Scott's yaml 🤞 
