### PR TITLE
move bernie back

### DIFF
--- a/members/S000033.yaml
+++ b/members/S000033.yaml
@@ -1,7 +1,6 @@
 #US Senator Bernie Sanders
 bioguide: S000033
 contact_form:
-  method: POST
   steps:
     - visit: "https://www.sanders.senate.gov/contact/contact-form/"
     - wait:


### PR DESCRIPTION
There's currently an issue with SCWC and submissions to Bernie Sanders are not being successfully delivered. As such, we're moving his yaml back to /members to attempt to deliver the stuck messages via form delivery. 


PS - I confirmed that you can manually submit Bernie's form with JS disabled. So submissions would most likley use `SimpleBrowser` instead of `phantom`

Feel the bern 🔥 