### PR TITLE
update success criteria; add js step

### DIFF
--- a/members/PAL000004.yaml
+++ b/members/PAL000004.yaml
@@ -1,7 +1,6 @@
 bioguide: PAL000004
 contact_form:
-  method: post
-  action: ""
+  driver: phantom
   steps:
     - visit: "http://www.senatorboscola.com/contact"
     - find:
@@ -54,7 +53,5 @@ contact_form:
     - find:
         - selector: div h1.entry-title
   success:
-    headers:
-      status: 200
     body:
-      contains: Thank You
+      contains: Your form was successfully submitted

--- a/members/PAL000460.yaml
+++ b/members/PAL000460.yaml
@@ -1,5 +1,6 @@
 bioguide: PAL000460
 contact_form:
+  driver: phantom
   steps:
   - visit: https://www.pahouseformcenter.com/355/RepStevenMentzer/SecureContact
   - find:
@@ -40,8 +41,17 @@ contact_form:
   - click_on:
     - value: Submit
       selector: '#ctl00_ContentPlaceHolder1_btnSubmitContact'
+  - javascript:
+    - name: success message
+      commands: ["var inter = setInterval(function() { if(document.location.pathname === '/SubmittedContact' ) { var msg = document.createElement('div'); msg.id='js-workaround'; msg.innerText='Javascript success message reached'; document.body.appendChild(msg); clearInterval(inter); } }, 100) "]
+      required: true
+  - find: # these three find steps are on purpose
+    - selector: "#js-workaround"
   - find:
-    - selector: .find-rep label
+    - selector: "#js-workaround"
+  - find:
+    - selector: "#js-workaround"      
   success:
     body:
-      contains: web submission has been received
+      contains: "Javascript success message reached"
+      excludes: "Your Message"

--- a/members/PAL000521.yaml
+++ b/members/PAL000521.yaml
@@ -1,5 +1,6 @@
 bioguide: PAL000521
 contact_form:
+  driver: phantom
   steps:
   - visit: https://www.pahouseformcenter.com/387/RepMartinaWhite/SecureContact
   - find:
@@ -40,8 +41,17 @@ contact_form:
   - click_on:
     - value: Submit
       selector: '#ctl00_ContentPlaceHolder1_btnSubmitContact'
+  - javascript:
+    - name: success message
+      commands: ["var inter = setInterval(function() { if(document.location.pathname === '/SubmittedContact' ) { var msg = document.createElement('div'); msg.id='js-workaround'; msg.innerText='Javascript success message reached'; document.body.appendChild(msg); clearInterval(inter); } }, 100) "]
+      required: true
+  - find: # these three find steps are on purpose
+    - selector: "#js-workaround"
   - find:
-    - selector: .find-rep label
+    - selector: "#js-workaround"
+  - find:
+    - selector: "#js-workaround"      
   success:
     body:
-      contains: web submission has been received
+      contains: "Javascript success message reached"
+      excludes: "Your Message"


### PR DESCRIPTION
Note: I'm adding the below JS step to `PAL000460` and `PAL000521`. Contact forms of these two targets aren't showing a success message after clicking submit ([screenshot](https://gyazo.com/14af56ce263c9f824cfe38aef6602796)).

> `var inter = setInterval(function() { if(document.location.pathname === '/SubmittedContact' ) { var msg = document.createElement('div'); msg.id='js-workaround'; msg.innerText='Javascript success message reached'; document.body.appendChild(msg); clearInterval(inter); } }, 100) `

This JS step checks if the URL's path is `/SubmittedContact` (which you'd get after submitting the form) and, if so, adds a fake text in the page that we then use for the yaml's success criteria (see small red square, bottom left, in this [screenshot](https://gyazo.com/4a250d9c872a9d3f368b6a43757e2359)). 

This JS step borrows heavily from other ones we're currently using for other US Sen yamls. Thanks to Tommy for suggesting this approach (awhile back in advo discussions room).