### PR TITLE
Update selectors for OTUSes yamls

### DIFF
--- a/members/federal_us_firstlady_jill_biden.yaml
+++ b/members/federal_us_firstlady_jill_biden.yaml
@@ -1,6 +1,5 @@
 bioguide: federal_us_firstlady_jill_biden
 contact_form:
-  method: post
   driver: phantom
   steps:
     - visit: "https://www.whitehouse.gov/contact/"
@@ -8,13 +7,13 @@ contact_form:
         - value: 5
     - select:
       - name: type
-        selector: select[id='Contact.Case.Who_are_you_trying_to_contact__c'] # these selectors are formatted this way on purpose - chrome dev tools has trouble parsing the id otherwise because of the period
+        selector: select[id*='Contact.Who_are_you_trying_to_contact__c'] # these selectors are formatted this way on purpose - chrome dev tools has trouble parsing the id otherwise because of the period
         value: Contact the President
         required: true
         options:
           Contact the President: Contact the President
       - name: Your Prefix
-        selector: select[id='Contact.Salutation']
+        selector: select[id*='Contact.Salutation']
         value: $NAME_PREFIX
         required: false
         options:
@@ -24,7 +23,7 @@ contact_form:
           Dr.: Dr.
           Mx.: Mx.
       - name: state
-        selector: select[id='Contact.MailingState']
+        selector: select[id*='Contact.MailingState']
         value: $ADDRESS_STATE_FULL
         required: true
         options:
@@ -93,42 +92,42 @@ contact_form:
           Wyoming: Wyoming
     - fill_in:
       - name: First Name
-        selector: input[id='Contact.FirstName']
+        selector: input[id*='Contact.FirstName']
         value: $NAME_FIRST
         required: true
       - name: Last Name
-        selector: input[id='Contact.LastName']
+        selector: input[id*='Contact.LastName']
         value: $NAME_LAST
         required: true
       - name: email
-        selector: input[id='Contact.Email']
+        selector: input[id*='Contact.Email']
         value: $EMAIL
         required: true
       - name: phone
-        selector: input[id='Contact.HomePhone']
+        selector: input[id*='Contact.HomePhone']
         value: $PHONE
         required: true
       - name: street
-        selector: textarea[id='Contact.MailingStreet']
+        selector: textarea[id*='Contact.MailingStreet']
         value: $ADDRESS_STREET
         required: true
       - name: city
-        selector: input[id='Contact.MailingCity']
+        selector: input[id*='Contact.MailingCity']
         value: $ADDRESS_CITY
         required: true
       - name: zip5
-        selector: input[id='Contact.MailingPostalCode']
+        selector: input[id*='Contact.MailingPostalCode']
         value: $ADDRESS_ZIP5
         required: true
       - name: message
-        selector: textarea[id='Contact.Case.Description']
+        selector: textarea[id*='Contact.Case.Description']
         value: $MESSAGE
         required: true
         options:
           blacklist: "\n"
-          max_length: 2000
+          max_length: 1900 # 100 less than actual max length of form to account for advo msg signature
     - click_on:
-      - selector: input[id='Contact.Contact_Us_Email_Opt_In__c']
+      - selector: input[id*='Contact.Contact_Us_Email_Opt_In__c']
     - find:
       - selector: input[type='submit'][value='Send']
     - click_on:

--- a/members/federal_us_president_joe_biden.yaml
+++ b/members/federal_us_president_joe_biden.yaml
@@ -1,6 +1,5 @@
 bioguide: federal_us_president_joe_biden
 contact_form:
-  method: post
   driver: phantom
   steps:
     - visit: "https://www.whitehouse.gov/contact/"
@@ -8,13 +7,13 @@ contact_form:
         - value: 5
     - select:
       - name: type
-        selector: select[id='Contact.Case.Who_are_you_trying_to_contact__c'] # these selectors are formatted this way on purpose - chrome dev tools has trouble parsing the id otherwise because of the period
+        selector: select[id*='Contact.Who_are_you_trying_to_contact__c'] # these selectors are formatted this way on purpose - chrome dev tools has trouble parsing the id otherwise because of the period
         value: Contact the President
         required: true
         options:
           Contact the President: Contact the President
       - name: Your Prefix
-        selector: select[id='Contact.Salutation']
+        selector: select[id*='Contact.Salutation']
         value: $NAME_PREFIX
         required: false
         options:
@@ -24,7 +23,7 @@ contact_form:
           Dr.: Dr.
           Mx.: Mx.
       - name: state
-        selector: select[id='Contact.MailingState']
+        selector: select[id*='Contact.MailingState']
         value: $ADDRESS_STATE_FULL
         required: true
         options:
@@ -93,42 +92,42 @@ contact_form:
           Wyoming: Wyoming
     - fill_in:
       - name: First Name
-        selector: input[id='Contact.FirstName']
+        selector: input[id*='Contact.FirstName']
         value: $NAME_FIRST
         required: true
       - name: Last Name
-        selector: input[id='Contact.LastName']
+        selector: input[id*='Contact.LastName']
         value: $NAME_LAST
         required: true
       - name: email
-        selector: input[id='Contact.Email']
+        selector: input[id*='Contact.Email']
         value: $EMAIL
         required: true
       - name: phone
-        selector: input[id='Contact.HomePhone']
+        selector: input[id*='Contact.HomePhone']
         value: $PHONE
         required: true
       - name: street
-        selector: textarea[id='Contact.MailingStreet']
+        selector: textarea[id*='Contact.MailingStreet']
         value: $ADDRESS_STREET
         required: true
       - name: city
-        selector: input[id='Contact.MailingCity']
+        selector: input[id*='Contact.MailingCity']
         value: $ADDRESS_CITY
         required: true
       - name: zip5
-        selector: input[id='Contact.MailingPostalCode']
+        selector: input[id*='Contact.MailingPostalCode']
         value: $ADDRESS_ZIP5
         required: true
       - name: message
-        selector: textarea[id='Contact.Case.Description']
+        selector: textarea[id*='Contact.Case.Description']
         value: $MESSAGE
         required: true
         options:
           blacklist: "\n"
-          max_length: 2000
+          max_length: 1900 # 100 less than actual max length of form to account for advo msg signature
     - click_on:
-      - selector: input[id='Contact.Contact_Us_Email_Opt_In__c']
+      - selector: input[id*='Contact.Contact_Us_Email_Opt_In__c']
     - find:
       - selector: input[type='submit'][value='Send']
     - click_on:

--- a/members/federal_us_vicepresident_kamala_harris.yaml
+++ b/members/federal_us_vicepresident_kamala_harris.yaml
@@ -1,6 +1,5 @@
 bioguide: federal_us_vicepresident_kamala_harris
 contact_form:
-  method: post
   driver: phantom
   steps:
     - visit: "https://www.whitehouse.gov/contact/"
@@ -8,13 +7,13 @@ contact_form:
         - value: 5
     - select:
       - name: type
-        selector: select[id='Contact.Case.Who_are_you_trying_to_contact__c'] # these selectors are formatted this way on purpose - chrome dev tools has trouble parsing the id otherwise because of the period
+        selector: select[id*='Contact.Who_are_you_trying_to_contact__c'] # these selectors are formatted this way on purpose - chrome dev tools has trouble parsing the id otherwise because of the period
         value: Contact the Vice President
         required: true
         options:
-          Contact the Vice President: Contact the Vice President
+          Contact the President: Contact the President
       - name: Your Prefix
-        selector: select[id='Contact.Salutation']
+        selector: select[id*='Contact.Salutation']
         value: $NAME_PREFIX
         required: false
         options:
@@ -24,7 +23,7 @@ contact_form:
           Dr.: Dr.
           Mx.: Mx.
       - name: state
-        selector: select[id='Contact.MailingState']
+        selector: select[id*='Contact.MailingState']
         value: $ADDRESS_STATE_FULL
         required: true
         options:
@@ -93,42 +92,42 @@ contact_form:
           Wyoming: Wyoming
     - fill_in:
       - name: First Name
-        selector: input[id='Contact.FirstName']
+        selector: input[id*='Contact.FirstName']
         value: $NAME_FIRST
         required: true
       - name: Last Name
-        selector: input[id='Contact.LastName']
+        selector: input[id*='Contact.LastName']
         value: $NAME_LAST
         required: true
       - name: email
-        selector: input[id='Contact.Email']
+        selector: input[id*='Contact.Email']
         value: $EMAIL
         required: true
       - name: phone
-        selector: input[id='Contact.HomePhone']
+        selector: input[id*='Contact.HomePhone']
         value: $PHONE
         required: true
       - name: street
-        selector: textarea[id='Contact.MailingStreet']
+        selector: textarea[id*='Contact.MailingStreet']
         value: $ADDRESS_STREET
         required: true
       - name: city
-        selector: input[id='Contact.MailingCity']
+        selector: input[id*='Contact.MailingCity']
         value: $ADDRESS_CITY
         required: true
       - name: zip5
-        selector: input[id='Contact.MailingPostalCode']
+        selector: input[id*='Contact.MailingPostalCode']
         value: $ADDRESS_ZIP5
         required: true
       - name: message
-        selector: textarea[id='Contact.Case.Description']
+        selector: textarea[id*='Contact.Case.Description']
         value: $MESSAGE
         required: true
         options:
           blacklist: "\n"
-          max_length: 2000
+          max_length: 1900 # 100 less than actual max length of form to account for advo msg signature
     - click_on:
-      - selector: input[id='Contact.Contact_Us_Email_Opt_In__c']
+      - selector: input[id*='Contact.Contact_Us_Email_Opt_In__c']
     - find:
       - selector: input[type='submit'][value='Send']
     - click_on:


### PR DESCRIPTION
Contact form selectors were slightly updated

- Old: `id="Contact.Salutation"`
- New: `id="form_61a6359aae5a3_Contact.Salutation"`

Changed the selectors in the yaml to `select[id*='Contact.MailingState']`, adding `*` that works as a `contains`

Also lowered by 100 the max _length option