### PR TITLE
van-108921: Ben Cardin update

### DIFF
--- a/members/C000141.yaml
+++ b/members/C000141.yaml
@@ -156,35 +156,6 @@ contact_form:
         value: $TOPIC
         required: true
         options:
-          Agriculture: Agriculture
-          Animal Rights: Animal Rights
-          Banking and Finance: Banking and Finance
-          Civil Rights: Civil Rights
-          Criminal Justice: Criminal Justice
-          Defense and Military: Defense and Military
-          Economy and Jobs: Economy and Jobs
-          Education: Education
-          Energy: Energy
-          Environment: Environment
-          Federal Budget: Federal Budget
-          Federal Courts and Judicial Nominations: Federal Courts and Judicial Nominations
-          Federal Employees: Federal Employees
-          Foreign Relations: Foreign Relations
-          Gun Safety: Gun Safety
-          Immigration: Immigration 
-          Health Care: Health Care
-          Homeland Security and Cybersecurity: Homeland Security and Cybersecurity
-          Housing: Housing
-          Labor: Labor
-          Politics and Political Campaigns: Politics and Political Campaigns
-          Safety Net and Public Assistance: Safety Net and Public Assistance
-          Social Security and Retirement: Social Security and Retirement
-          Space, Science & Technology: Space, Science and Technology
-          Tax Policy and Reform: Tax Policy and Reform
-          Telecommunications: Telecommunications
-          Transportation: Transportation
-          Veterans: Veterans
-          Voting Rights: Voting Rights
           Other: Other
     - fill_in:
       - name: first
@@ -232,7 +203,7 @@ contact_form:
     - javascript:
       - name: char replace
         values: ["$MESSAGE"]
-        selectors: ["textarea#input-B03E05B4-4040-F985-52CD-8DF0BC10EEE2"]
+        selectors: ["textarea#input_3_6"]
         commands: ["for(var i = 0; i < elements.length; i++) { elements[i].value = elements[i].replace(/(%2[0])/g, '').replace(/(CC:)/g,'CC').replace(/[(]/g,'[').replace(/[)]/g,']');}"]
         required: true
     - find: 


### PR DESCRIPTION
I removed the options from the topic dropdown to see if that would help yamltron register that field

https://ngpvan.atlassian.net/browse/VAN-108921

These are the errors I was seeing:  Formula element could not be acted on {"errorMessage":"undefined is not a constructor (evaluating 'elements[i].replace(/(%2[0])/g, '')')",

Looks like it was referring to the message section. I think the message section isn't being picked up because the topic drop down isn't being selected. example screenshot:  https://s3.amazonaws.com/yamltron-dev/screenshots/final/0f7ab5ce-d402-452e-9035-c1e565d29c05.png