### PR TITLE
van-108921: Ben Cardin

### DIFF
--- a/members/C000141.yaml
+++ b/members/C000141.yaml
@@ -1,6 +1,7 @@
 #US Senator Ben Cardin
 bioguide: C000141
 contact_form:
+  driver: chrome
   method: POST
   steps:
     - visit: "https://www.cardin.senate.gov/email-ben/"

--- a/members/C000141.yaml
+++ b/members/C000141.yaml
@@ -1,7 +1,6 @@
 #US Senator Ben Cardin
 bioguide: C000141
 contact_form:
-  driver: chrome
   method: POST
   steps:
     - visit: "https://www.cardin.senate.gov/email-ben/"
@@ -157,6 +156,35 @@ contact_form:
         value: $TOPIC
         required: true
         options:
+          Agriculture: Agriculture
+          Animal Rights: Animal Rights
+          Banking and Finance: Banking and Finance
+          Civil Rights: Civil Rights
+          Criminal Justice: Criminal Justice
+          Defense and the Military: Defense and the Military
+          Economy and Jobs: Economy and Jobs
+          Education: Education
+          Energy: Energy
+          Environment: Environment
+          Federal Budget: Federal Budget
+          Federal Courts and Judicial Nominations: Federal Courts and Judicial Nominations
+          Federal Employees: Federal Employees
+          Foreign Relations: Foreign Relations
+          Gun Safety: Gun Safety
+          Immigration: Immigration
+          Health Care: Health Care
+          Homeland Security and Cybersecurity: Homeland Security and Cybersecurity
+          Housing: Housing
+          Labor: Labor
+          Politics and Political Campaigns: Politics and Political Campaigns
+          Safety Net and Public Assistance: Safety Net and Public Assistance
+          Social Security and Retirement: Social Security and Retirement
+          Space, Science & Technology: Space, Science & Technology
+          Tax Policy and Reform: Tax Policy and Reform
+          Telecommunications: Telecommunications
+          Transportation: Transportation
+          Veterans: Veterans
+          Voting Rights: Voting Rights
           Other: Other
     - fill_in:
       - name: first
@@ -201,6 +229,8 @@ contact_form:
         required: true
         options:
           blacklist: "-,;—:()"
+    - wait: 
+      - value: 5
     - javascript:
       - name: char replace
         values: ["$MESSAGE"]


### PR DESCRIPTION
Still seeing ""undefined is not a constructor (evaluating 'elements[i].replace(/(%2[0])/g, '')')"," errors. 

I looked up the error online and [this](https://stackoverflow.com/questions/38928987/typeerror-undefined-is-not-a-constructor) stack overflow page indicates that "undefined is not a constructor" is a PhantomJs error. 

The page says this error "is an error message PhantomJS displays when you tried to call a function that is not defined"

Because there was no specified chrome driver in my last committ, it defaulted to PhantomJs and I'm wondering if that could be why we're getting these errors, as indicated in the stack overflow site above.

I added the chrome driver in to see if this gets rid of the errors. 

Ticket: https://ngpvan.atlassian.net/browse/VAN-108921
