### PR TITLE
van-113301: Increased wait time for Gov. Dog Burgums form

### DIFF
--- a/members/state_nd_gov_doug_burgum.yaml
+++ b/members/state_nd_gov_doug_burgum.yaml
@@ -6,7 +6,7 @@ contact_form:
   steps:
     - visit: "https://www.governor.nd.gov/contact-us"
     - wait:
-        - value: 3
+        - value: 10
     - fill_in:
         - name: First name
           selector: "#edit-your-first-name"


### PR DESCRIPTION
Increased the wait time to 10. When testing locally I get a "please wait 11 seconds and try again" [error](https://gyazo.com/396375d6eb074534b2cf3638298f7dd4), and then the form fails to submit. I think the form is submitting too fast. Increasing the wait time seems to solve this. [ticket](https://ngpvan.atlassian.net/browse/VAN-113301)