### PR TITLE
Kristen Gillibrand Driver Update

### DIFF
--- a/members/G000555.yaml
+++ b/members/G000555.yaml
@@ -1,7 +1,6 @@
 #US Senator Kristen Gillibrand
 bioguide: G000555
 contact_form:
-  driver: chrome
   method: post
   steps:
     - visit: "https://www.gillibrand.senate.gov/contact/email-me"


### PR DESCRIPTION
Removed chrome driver -- the chrome flag is causing a ton of "chrome not reachable" and "driver cannot start errors" success rate is only around14%.  

Going to try to do further debugging with this one once the chrome flag is removed 