### PR TITLE
eva-24524: Another Scott Wiener Update

### DIFF
--- a/members/xCA_U_Wiener.yaml
+++ b/members/xCA_U_Wiener.yaml
@@ -41,16 +41,17 @@ contact_form:
           options:
             max_length: 2000
           required: true
+    - select: 
+        - name: topic
+          selector: "#IssueListBox"
+          required: false
+          options: 
+            37708: Issue - Other
     - wait: 
         - value: 3
     - javascript:
       - selector: ["#submitButton"]
-        commands: ["var r=arguments[0][0].getBoundingClientRect(); var cx=r.left+r.width/2, cy=r.top+r.height/2; var e=document.elementFromPoint(cx,cy); console.log('OVERLAY at button center ('+cx+','+cy+'):', e && e.outerHTML.substring(0,300));"]
-    - wait: 
-        - value: 3
-    - javascript:
-      - selector: ["#submitButton"]
-        commands: ["document.querySelector('#submitButton').scrollIntoView({block:'center'}); document.querySelector('#submitButton').click();"]
+        commands: ["var f=document.querySelector('iframe.contact-form'); var d=(f&&(f.contentDocument||f.contentWindow.document))||document; var b=d.querySelector('#submitButton'); if(b){b.scrollIntoView({block:'center'}); b.click();}"]
     - wait: 
         - value: 3
   success:


### PR DESCRIPTION
ticket: https://bonterra.atlassian.net/browse/EVA-24524

  Replaced the click_on + broken javascript steps with one frame-aware JS step that performs the click directly and added a topic drop down
  
The form lives inside iframe.contact-form. This script works whether Selenium's JS context is the top page or already inside the
  iframe — it looks for the iframe and dives in if present, otherwise uses the current document.
  A JS .click() fires the click event directly on the element. Unlike Selenium's native .Click(), it doesn't perform a viewport
  hit-test, so it isn't blocked by overlapping elements.